### PR TITLE
Chapter 10-14 reordered

### DIFF
--- a/src/10-mutation/mutation.md
+++ b/src/10-mutation/mutation.md
@@ -2,21 +2,22 @@
 
 The content of this chapter is available as a scala file [here.](./mutation.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.language.implicitConversions
+```
 
-/**
-Mutation
-========
 Today we study _mutation_. More specifically, we want to equip our language with mutable data structures.
+
 Typical mutable data structures in common languages include objects with mutable fields or structures/records in languages like C or Pascal.
 We will study a particularly simple mutable data structure: Boxes. In OO parlance, boxes can be thought of as an object with
 a single field that can be mutated. Despite their simplicity, boxes already illustrate all main issues associated with adding
 mutable state to a language.
+
 A different and less interesting form of mutation is the mutability of _variables_, such as the possibility to assign something
 to a 'local' variable bound via a lambda or ``with``. We will not talk about mutable variables today.
 We will add boxes to our base language, FAE.
-*/
+
+```scala mdoc
 object Syntax {
   sealed abstract class Exp
   case class Num(n: Int) extends Exp
@@ -40,114 +41,132 @@ object Syntax {
   case class Seq(e1: Exp, e2: Exp) extends Exp // sequencing of expressions
 }
 import Syntax._
-/**
-In this new language, the following sample program,
-*/
+```
 
+In this new language, the following sample program,
+
+```scala mdoc:silent
 val test1 = wth("b", NewBox(0),
               Seq(
                 SetBox("b", Add(1, OpenBox("b"))),
                 OpenBox("b")))
+```
 
-/**
 should give as result ``1`` in a proper implementation.
 Let's consider how our interpreter could handle sequencing.
+
 Here is an attempt:
+```
      case Seq(e1, e2) => {
        eval(e1, env)
        eval(e2, env)
      }
+```
+
 This cannot be correct. As long as our interpreter does not use mutation, evaluation could not make any changes to the environment,
 hence there is* no way the evaluation of e1 could have any effect on the evaluation of e2.
+
 In order to demostrate the actual nature of mutation, we will not use mutation in our meta-language to implement mutation
 in our object language. That said, we will not use a mutable data structure to implement environment in our interpreter.
 Instead, one may turn to the so-called environment-passing style, in which the interpreter returns also a possibly updated environment
 together with the computed value when it evaluates an expression.  However, this solution does not always work.  Consider the following
 example:
-*/
 
+```scala mdoc:silent
 val test2 = wth("a", NewBox(1),
               wth("f", Fun("x", Add("x", OpenBox("a"))),
                 Seq(SetBox("a",2),
                   Ap("f", 5))))
+```
 
-/**
 The mutation should affect the box stored in the closure bound to ``f``.  But with the implementation strategy described above it would not.
 Note that changing the value of a in the example is not a vialation of static scope.  Scoping only says where an identifier is bound;
 it does not say to what an identifier is bound, in particular, whether whatever bound to the identifier is fixed.
+
 Indeed, the variable a is bound to the same box in both the static environment where the function f is created and the dynamic environment
 where the function f is applied.
-As before, when applying the function f to the argument 5, we can choose either
+
+As before, when applying the function f to the argument 5, we can choose either#
+
    1) To use the static environment (where the variable a is bound to a boxed 1) stored in the closure created for f.
+
    2) Or to use the dynamic environment (where the variable a is bound to a  boxed 2) present at the time of applying f.
+
 The first choice leads the program to evaluate to 6 rather than the expected 7.  The second will record the change to the box,
 but it reintroduces dynamic scoping.  So both choices do not work.
 Insight: We need _two_ repositories of information.
 One, the environment, guards static scope.
-*/
 
+```scala mdoc
 sealed abstract class Value
 type Env = Map[String, Value]
 case class NumV(n: Int) extends Value
 case class ClosureV(f: Fun, env: Env) extends Value
+```
 
-/**
 The other, which we call _store_, is trackis dynamic changes.
 Determining the value inside a box will become a two-step process: We first evaluate the box expression to an _address_,
 and then use the store to lookup the value stored at that address. We choose to represent addresses by integers.
-*/
 
+```scala mdoc
 type Address = Int
 case class AddressV(a: Address) extends Value
 
 type Store = Map[Address, Value]
+```
 
-/**
 We will often need a fresh address in the store. We do so using a counter variable.
-*/
 
+```scala mdoc
 var _nextAddress = 0
 
 def nextAddress : Address = {
   _nextAddress += 1
   _nextAddress
 }
+```
 
-/**
-Note: We promised to implement the interpreter without using mutation. Here we did use mutation, but this musage of mutation
+Note: We promised to implement the interpreter without using mutation. Here we did use mutation, but this usage of mutation
 is not essential: we could instead just search for the largest address in the present store and add one to it.
 Let's now discuss the evaluation of FAE with conditionals and boxes, BCFAE. To this end, consider the following sample program:
-*/
 
+```scala mdoc:silent
 val test3 = wth("switch", NewBox(0),
              wth("toggle", Fun("dummy", If0(OpenBox("switch"),
                                           Seq(SetBox("switch", 1), 1),
                                           Seq(SetBox("switch", 0), 0))),
                  Add(Ap("toggle",42), Ap("toggle",42))))
+```
 
-/**
 This program should return 1. Let's discuss on the blackboard what the environment and store should look like during the
 evaluation of this program.
-ID      Exp                     Value   Env             Store
-A       wth(..                          "switch" -> ..   1 -> NumV(0)
-B        wth(..                         "toggle" -> ..
-C         Add(..
-D          Ap("toggle")         1                       1 -> NumV(1)
-E          Ap("toggle")         0                       1 -> NumV(0)
-F         Add(0,1)              1
+
+| ID | Exp | Value | Env | Store |
+|---|---|---|---|---|
+| A | wth(.. |  | "switch" -> . | 1 -> NumV(0) |
+| B |  wth(.. |  | "toggle" -> .. |  |
+| C |   Add(.. |  |  |  |
+| D |    Ap("toggle") | 1 |  | 1 -> NumV(1) |
+| E |    Ap("toggle") | 0 |  | 1 -> NumV(0) |
+| F |   Add(0,1) | 1 |  |  |
+
 Insight:
 We must pass the current store in to evaluate every expression and pass the possibly updated store out after the evaluation.
 This is called _store-passing style:.  Consequently, we have to update the type of our evaluator.
-*/
 
+
+```scala mdoc
 def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
   /* All expressions whose evaluation does not alter the store just return s. */
   case Num(n) => (NumV(n), s)
   case Id(x) => (env(x), s)
   case f@Fun(_, _) => (ClosureV(f, env), s)
-  /* In recursive cases we have to thread the store through the
-   * evaluation. In particular, we define the order of evaluation
-   * explicitly through data flow dependencies.  */
+  ```
+
+  In recursive cases we have to thread the store through the
+   evaluation. In particular, we define the order of evaluation
+   explicitly through data flow dependencies.
+   ```scala mdoc
   case If0(cond, thenExp, elseExp)
     => eval(cond, env, s) match {
          case (NumV(0), s1) => eval(thenExp, env, s1)
@@ -189,13 +208,13 @@ def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
               }
          case _ => sys.error("can only apply functions")
        }
-
-  /* In a sequence, we ignore the result of evaluating e1 but not its
-   * effect on the store. */
+```
+In a sequence, we ignore the result of evaluating e1 but not its effect on the store.
+```scala mdoc
   case Seq(e1, e2) => eval(e2, env, eval(e1, env, s)._2)
-
-  /* A new box is created by putting it into the store at a new
-   * address.  */
+```
+  A new box is created by putting it into the store at a new address.
+  ```scala mdoc
   case NewBox(e: Exp)
     => eval(e, env, s) match {
          case (v, s1) => {
@@ -203,10 +222,12 @@ def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
            (AddressV(a), s1 + (a -> v))
          }
        }
+```
 
-  /* Setting a box is now a two-step process: First evaluate b to an
-   * address, then lookup and update the value associated to the
-   * address in the store. Note that "updated" is a functional method.  */
+Setting a box is now a two-step process: First evaluate b to an
+address, then lookup and update the value associated to the
+address in the store. Note that "updated" is a functional method.
+```scala mdoc
   case SetBox(b: Exp, e: Exp)
     => eval(b, env, s) match {
          case (AddressV(a), s1)
@@ -215,25 +236,28 @@ def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
               }
          case _ => sys.error("can only set boxes")
        }
+```
+  OpenBox uses the same two-step process but does not update the
+  store.
 
-  /* OpenBox uses the same two-step process but does not update the
-   * store.  */
+```scala mdoc
   case OpenBox(b: Exp)
     => eval(b, env, s) match {
          case (AddressV(a), s1) => (s1(a), s1)
          case _                 => sys.error("can only open boxes")
        }
 }
+```
 
-/**
 From an implementation point of view, our interpreter has the problem that nothing is ever removed from the store.
 One possibility would be to add an operation "removeBox" or the like to the language, but this would lead to dangling pointers
 and all the* problems associated with manual memory management.
+
 Our model of stores is sufficient to illustrate how modern languages deal with memory management: by garbage collection.
 Garbage collectors automatically reclaim memory that is no longer referenced from within the active part of the computation.
 We can* model a (naive) mark-and-sweep garbage collector as follows:
-*/
 
+```scala mdoc:silent
 def gc(env: Env, store:Store) : Store = {
 
   def allAddrInVal(v: Value) : Set[Address] = v match {
@@ -254,7 +278,8 @@ def gc(env: Env, store:Store) : Store = {
   val marked = mark(allAddrInEnv(env)) // mark ...
   store.view.filterKeys(marked(_)).toMap           // and sweep!
 }
-
+```
+```scala mdoc
 val teststore = Map(
   6  -> NumV(42),
   7  -> NumV(6),
@@ -268,13 +293,16 @@ val teststore = Map(
       9 -> 7        */
 
 assert(gc(Map("a" -> AddressV(10)), teststore) == teststore - 7 - 9)
+```
 
-/**
+
 Note that garbage collectors only _approximate_ the set of semantically disposable store entities. Even with garbage collectors,
 applications may very well suffer from memory leaks. The approximation should be _safe_, in the sense that a datum is never reclaimed
-when it is used by subsequent computations. Furthermore, it must reclaim enough garbage to be actually useful. Reachability has turned
+when it is used by subsequent computations.
+
+Furthermore, it must reclaim enough garbage to be actually useful. Reachability has turned
 out to be a rather useful (and sound) approximation of semantic disposability. Garbage collectors must also be efficient.
 Efficiency of GC is a huge research topic that we are not going to discuss. One efficiency problem with garbage collectors based on
 reachability that we want to mention is the "stop-the-world" phenomenon.
- */
+
 ```

--- a/src/10-mutation/mutation.md
+++ b/src/10-mutation/mutation.md
@@ -56,6 +56,7 @@ should give as result ``1`` in a proper implementation.
 Let's consider how our interpreter could handle sequencing.
 
 Here is an attempt:
+
 ```
      case Seq(e1, e2) => {
        eval(e1, env)
@@ -152,7 +153,7 @@ evaluation of this program.
 
 Insight:
 We must pass the current store in to evaluate every expression and pass the possibly updated store out after the evaluation.
-This is called _store-passing style:.  Consequently, we have to update the type of our evaluator.
+This is called _store-passing style_.  Consequently, we have to update the type of our evaluator.
 
 
 ```scala mdoc
@@ -161,12 +162,11 @@ def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
   case Num(n) => (NumV(n), s)
   case Id(x) => (env(x), s)
   case f@Fun(_, _) => (ClosureV(f, env), s)
-  ```
 
-  In recursive cases we have to thread the store through the
-   evaluation. In particular, we define the order of evaluation
-   explicitly through data flow dependencies.
-   ```scala mdoc
+
+// In recursive cases we have to thread the store through the evaluation. In particular, we define the order of evaluation
+// explicitly through data flow dependencies.
+
   case If0(cond, thenExp, elseExp)
     => eval(cond, env, s) match {
          case (NumV(0), s1) => eval(thenExp, env, s1)
@@ -208,13 +208,14 @@ def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
               }
          case _ => sys.error("can only apply functions")
        }
-```
-In a sequence, we ignore the result of evaluating e1 but not its effect on the store.
-```scala mdoc
+
+
+// In a sequence, we ignore the result of evaluating e1 but not its effect on the store.
+
   case Seq(e1, e2) => eval(e2, env, eval(e1, env, s)._2)
-```
-  A new box is created by putting it into the store at a new address.
-  ```scala mdoc
+
+//  A new box is created by putting it into the store at a new address.
+
   case NewBox(e: Exp)
     => eval(e, env, s) match {
          case (v, s1) => {
@@ -222,12 +223,11 @@ In a sequence, we ignore the result of evaluating e1 but not its effect on the s
            (AddressV(a), s1 + (a -> v))
          }
        }
-```
 
-Setting a box is now a two-step process: First evaluate b to an
-address, then lookup and update the value associated to the
-address in the store. Note that "updated" is a functional method.
-```scala mdoc
+// Setting a box is now a two-step process: First evaluate b to an
+// address, then lookup and update the value associated to the
+// address in the store. Note that "updated" is a functional method.
+
   case SetBox(b: Exp, e: Exp)
     => eval(b, env, s) match {
          case (AddressV(a), s1)
@@ -236,11 +236,10 @@ address in the store. Note that "updated" is a functional method.
               }
          case _ => sys.error("can only set boxes")
        }
-```
-  OpenBox uses the same two-step process but does not update the
-  store.
 
-```scala mdoc
+// OpenBox uses the same two-step process but does not update the
+// store.
+
   case OpenBox(b: Exp)
     => eval(b, env, s) match {
          case (AddressV(a), s1) => (s1(a), s1)
@@ -257,7 +256,7 @@ Our model of stores is sufficient to illustrate how modern languages deal with m
 Garbage collectors automatically reclaim memory that is no longer referenced from within the active part of the computation.
 We can* model a (naive) mark-and-sweep garbage collector as follows:
 
-```scala mdoc:silent
+```scala mdoc
 def gc(env: Env, store:Store) : Store = {
 
   def allAddrInVal(v: Value) : Set[Address] = v match {
@@ -279,6 +278,7 @@ def gc(env: Env, store:Store) : Store = {
   store.view.filterKeys(marked(_)).toMap           // and sweep!
 }
 ```
+
 ```scala mdoc
 val teststore = Map(
   6  -> NumV(42),
@@ -304,5 +304,3 @@ Furthermore, it must reclaim enough garbage to be actually useful. Reachability 
 out to be a rather useful (and sound) approximation of semantic disposability. Garbage collectors must also be efficient.
 Efficiency of GC is a huge research topic that we are not going to discuss. One efficiency problem with garbage collectors based on
 reachability that we want to mention is the "stop-the-world" phenomenon.
-
-```

--- a/src/11-garbage-collection/garbage-collection.md
+++ b/src/11-garbage-collection/garbage-collection.md
@@ -2,21 +2,17 @@
 
 The content of this chapter is available as a Scala file [here.](./garbage-collection.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.language.implicitConversions
-/**
-Garbage Collection
-==================
+```
+
 Let us now consider a more accurate modeling of garbage collection (gc). This time, we will use a mutable store instead of
 a functional store, because our purpose is not to explain mutation but to explain gc.
-*/
 
 
+This is the well-known syntax of our language: FAE with boxes.
 
-/**
-This is the well-known syntax of our language: FAE with boxes. 
-*/
-
+```scala mdoc
 sealed abstract class Exp
 case class Num(n: Int) extends Exp
 case class Id(name: String) extends Exp
@@ -33,43 +29,44 @@ case class NewBox(e: Exp) extends Exp
 case class SetBox(b: Exp, e: Exp) extends Exp
 case class OpenBox(b: Exp) extends Exp
 case class Seq(e1: Exp, e2: Exp) extends Exp
+```
 
-/** 
+
 We will equip our values with a mutable flag that is useful for mark-and-sweep garbage collection.
 In real systems it is implemented as a bit flag, or, if the so-called "tri-color algorithm" is used, with two bit flags.
-*/
 
-abstract class Value { 
+```scala mdoc
+abstract class Value {
   var marked : Boolean = false
 }
+```
 
-/** 
 We will also use a mutable map instead of a map for environments. This is not needed for mark-and-sweep,
 but for copying garbage collectors such as Cheney"s" semi-space garbage collection algorithm.
-*/
 
+```scala mdoc
 type Env = scala.collection.mutable.Map[String, Value]
 case class NumV(n: Int) extends Value
 case class ClosureV(f: Fun, env: Env) extends Value
 case class AddressV(a: Int) extends Value
+```
 
-/** 
 To be able to experiment with different store and gc designs, we create an interface for stores.
 The stack parameter in malloc is needed during gc to determine the root nodes from which the algorithms can start.
-*/
 
+```scala mdoc
 trait Store {
   def malloc(stack: List[Env], v: Value) : Int
   def update(index: Int, v: Value) : Unit
   def apply(index: Int) : Value
 }
+```
 
-/** 
 In our interpreter, the stack of environments is only implicitly available on the stack of the meta-language.
 To reify the call-stack we need to make it explicit. We do so by constructing the stack explicitly and passing it as parameter.
 The first element of the stack is the current environment; the rest is only needed for gc.
-*/
 
+```scala mdoc
 def eval(e: Exp, stack: List[Env], store: Store) : Value = e match {
 
   case Num(n) => NumV(n)
@@ -150,11 +147,13 @@ def eval(e: Exp, stack: List[Env], store: Store) : Value = e match {
          case _ => sys.error("can only open boxes")
        }
 }
+```
 
-/** 
+
 Here is one implementation of the Store interface that does not perform gc. It just runs out of memory once the store is full.
-*/
 
+
+```scala mdoc
 class NoGCStore(size: Int) extends Store {
 
   val memory = new Array[Value](size)
@@ -173,11 +172,11 @@ class NoGCStore(size: Int) extends Store {
 
   def apply(index: Int) = memory(index)
 }
+```
 
-/** 
 Here is a mark-and-sweep garbage collector.
-*/
 
+```scala mdoc
 class MarkAndSweepStore(size: Int) extends Store {
 
   val memory = new Array[Value](size)
@@ -261,46 +260,49 @@ class MarkAndSweepStore(size: Int) extends Store {
             "\nNUMBER OF FREE SLOTS = " + free)
   }
 }
+```
 
+```scala mdoc:silent
 val test4 = wth("makedata", Fun("x", NewBox(NewBox(NewBox("x")))),
                 Seq(Ap("makedata", 1),
                 Seq(Ap("makedata", 2),
                 Seq(wth("s", Ap("makedata", 3),
                             Ap("makedata", "s")),
                     Ap("makedata", 4)))))
+```
 
+```scala mdoc
 def runTest4 = eval(
                  test4,
                  List(scala.collection.mutable.Map.empty),
                  new MarkAndSweepStore(5)
                )
+```
 
-/** 
 This model of garbage collection does not illustrate the difficulty of memory management. In most languages, the size of
 the allocated memory regions on the heap vary, and hence one needs an algorithm to find a free and large-enough spot on the heap.
 There are various algorithms and heuristics (best-fit, worst-fit, first-fit, ...) for that purpose.
+
 There are also various alternative gc designs. Mark-and-sweep is a non-moving algorithm, where reachable heap objects are never moved.
 In contrast to that, copying gc algorithms move the reachable objects to a different portion of the heap. One of the oldest algorithms
 is the semi-space garbage collector, in particular with the implementation purpose.
      http://www.cs.umd.edu/class/fall2002/cmsc631/cheney/cheney.html
 Topic for class discussion: What are the pros and cons of moving vs. non-moving gc?
- 
+
 It can be shown empirically that most unreachable objects become unreachable while they are still young. Generational gc algorithms
 take this empirical fact into account and divide the objects into generations, whereby the (small) youngest generation of objects
 is garbage-collected more frequently.
- 
+
 A typical problem of the simple gc algorithms we discussed is the stop-the-world phenomenon: All execution has to be stopped during
 a gc cycle. This issue is addressed by incremental or concurrent garbage collectors. Incremental garbage collectors typically reduce*
 the total throughput but increase responsiveness and real-time behavior.
- 
+
 A completely different approach to memory management is _reference counting_. In reference counting, each object on the heap
 (in our case, each box) maintains a counter which says how many pointers currently point to that object. The counter is adjusted
 whenever a pointer variable is assigned to this object (incremented), or from this object to another object (decremented).
 When the counter is 0, the object can be reclaimed.
+
 The obvious disadvantage of reference counting is that it cannot detect cycles on the heap. Hence reference counting algorithm
 must be augmented with some means to detect cycles.
 Topic for class discussion: What are the pros and cons of reference counting vs. tracing garbage collectors such as mark-and-sweep
 or semi-space?
-*/
-
-```

--- a/src/12-meta-interpretation/meta-interpretation.md
+++ b/src/12-meta-interpretation/meta-interpretation.md
@@ -2,32 +2,34 @@
 
 The content of this chapter is available as a Scala file [here.](./meta-interpretation.scala)
 
-```scala mdoc
-/**
-Syntactic interpretation vs meta intepretation
-==============================================
+
 For each desired language semantics, there exist many different ways to implement an interpreter in some meta-language
 to encode this semantics.
+
 One question that is of particular importance is whether a language feature is implemented by using a corresponding
 language feature of the meta-language, or whether it is implemented using more primitive language constructs.
-The first case is called meta-interpretation, the second case syntactic interpretation. 
+The first case is called meta-interpretation, the second case syntactic interpretation.
+
 Meta-interpretation can be convenient if we are not interested in having control over the exact meaning of the construct,
 or if the way the meta-language handles this construct is just what we want for our object language.
+
 Syntactic interpretation is required if we want to understand what the language feature really means in terms
 of more primitive constructs, or if we want to implement the language feature differently than the meta language.
 Of course, if the meta language has no corresponding feature, then we have no choice but to make a syntactic interpretation.
+
 Our FAE interpreter is a meta-interpreter with respect to many features. For instance, it does not tell us
- * the precision of numbers, or the algorithm for addition
- * how the call stack is managed, e.g. the maximum depth of recursion supported by the interpreter
- * whether/how memory management for closures works (they are objects on the heap!)
+ - the precision of numbers, or the algorithm for addition
+ - how the call stack is managed, e.g. the maximum depth of recursion supported by the interpreter
+ - whether/how memory management for closures works (they are objects on the heap!)
+
 That said, it is possible to make the FAE interpreters still more "meta". Here are two examples.
 Here is a version of FAE that uses a different representation of the program syntax, namely one using meta-language functions
 to represent object-language functions. This technique is called higher-order abstract syntax, or HOAS.
 For instance, the function ``Fun('x, Add('x,5))`` is now represented as ``Fun( x => Add(x,5))``.
 The interpreter becomes rather short, because substitution and lexical scoping are now being dealt with by the
 corresponding meta-level construct.
-*/
 
+```scala mdoc
 object HOAS {
     sealed abstract class Exp
     case class Num(n: Int) extends Exp
@@ -48,21 +50,23 @@ object HOAS {
       case _ => e // numbers and functions evaluate to themselves
     }      
 }
+```
 
-/** 
 A different way to use meta-level functions in the interpreter is to represent object-level closures by meta-level closures.
-Notice that this interpreter has no control anymore about scoping;  rather, it is completely inherited from the meta language. 
+Notice that this interpreter has no control anymore about scoping;  rather, it is completely inherited from the meta language.
+
 A particularly pleasing and important property of this interpreter is that it is _compositional_, meaning that all recursive calls
 of eval are only on subparts of the original expression. This means that it becomes particularly easy to reason about program equivalence
 in the object language in terms of program equivalence in the meta language: Two object language expressions are equivalent if their
-"denotations" as meta-level expressions are equivalent in the meta-level. 
- 
+"denotations" as meta-level expressions are equivalent in the meta-level.
+
 Compositionality is the cornerstone of denotational semantics.  A denotational semantics can be thought of as a
 compositional interpreter in which the meta-language is mathematics.
 Compositionality also has a rather practical side-effect: It means that we can implement the interpreter in the internal visitor style
 that  we learned about in the first lecture (recall that the internal visitor  style enforces compositionality)
-Recommended exercise: Re-implement the interpreter as an internal visitor. 
-*/
+Recommended exercise: Re-implement the interpreter as an internal visitor.
+
+```scala mdoc
 sealed abstract class Exp
 case class Num(n: Int) extends Exp
 case class Id(name: String) extends Exp
@@ -70,7 +74,7 @@ case class Add(lhs: Exp, rhs: Exp) extends Exp
 case class Fun(param: String, body: Exp) extends Exp
 case class Ap (funExpr: Exp, argExpr: Exp) extends Exp
 
-object Compositional { 
+object Compositional {
     sealed abstract class Value
     type Env = Map[String, Value]
     case class NumV(n: Int) extends Value
@@ -93,11 +97,11 @@ object Compositional {
       }
     }
 }
+```
 
-/** 
-For comparison, here is our original FAE interpreter. 
-*/
+For comparison, here is our original FAE interpreter.
 
+```scala mdoc
 object FAE {
     sealed abstract class Value
     type Env = Map[String, Value]
@@ -121,15 +125,15 @@ object FAE {
       }
     }
 }
+```
 
-/** 
 We will soon learn about ways to make FAE more syntactic in various ways. For instance, we will no longer rely on call-stack management
 of the meta-language, or the existence of higher-order functions.
+
 One dimension in which the interpreter could easily be made more syntactic is the treatment of numbers and arithmetic.
-For instance, we could represent numbers as sequences of digits instead of Scala numbers. 
+For instance, we could represent numbers as sequences of digits instead of Scala numbers.
 Another aspect in which our FAE interpreter relies on the host language is memory management.
+
 This is particularly relevant for environments stored inside closures. These environments cannot be organized on the call stack
 and hence need memory management. Since we are using Scala references to refer to environments, environments that are no longer
 needed are collected by the Scala (or rather, Java) virtual machine.
-*/
-```

--- a/src/13-church-encoding/church-encoding.md
+++ b/src/13-church-encoding/church-encoding.md
@@ -2,14 +2,11 @@
 
 The content of this chapter is available as a Scala file [here.](./church-encoding.scala)
 
-```scala mdoc
-/**
-Church Encoding
-===============
 Today we shrink our language. It does not seem to be big, but today we want to  illustrate how powerful our core language,
 the lambda calculus, is. Here is a shrinked version of FAE that does not even have numbers anymore. For testing purposes,
-we introduce a new expression ``PrintDot`` whose semantics is to print a dot on the screen. 
-*/
+we introduce a new expression ``PrintDot`` whose semantics is to print a dot on the screen.
+
+```scala mdoc
 sealed abstract class Exp
 case class Id(name: String) extends Exp
 implicit def id2exp(s: String): Exp = Id(s)
@@ -20,46 +17,49 @@ case class PrintDot() extends Exp
 abstract class Value // the only values are closures
 type Env = Map[String, Value]
 case class ClosureV(f:Fun, env:Env) extends Value
+```
 
-/** 
 Notice that the only values in this language are closures. This means that there cannot be the situation anymore that we expect,
-say, a number but get in fact a closure. Hence, this language has the fascinating property that  no dynamic type errors can occur. 
-*/
- 
+say, a number but get in fact a closure. Hence, this language has the fascinating property that  no dynamic type errors can occur.
+
+```scala mdoc
 def eval(e: Exp, env: Env) : Value = e match {
   // We give the identity function as dummy value for PrintDot
-  case PrintDot() => print("."); ClosureV(Fun("x","x"), Map.empty) 
+  case PrintDot() => print("."); ClosureV(Fun("x","x"), Map.empty)
   case Id(x) => env(x)
   case f@Fun(param,body) => ClosureV(f, env)
   case Ap(f,a) => eval(f,env) match {
     case ClosureV(f,closureEnv) => eval(f.body, closureEnv + (f.param -> eval(a,env)))
   }
 }
+```
 
-/** 
 Now we want to illustrate that we can, in principle, bootstrap a full programming language from this small core.
 To do so, we use the technique of Church encoding. This means that each datum is represented by its own fold function.
 Church Encoding of Booleans
----------------------------
-Let"s" start with booleans and boolean arithmetic. 
-*/
+
+Let"s" start with booleans and boolean arithmetic.
+
+```scala mdoc:silent
 val f = Fun("t", Fun("f", "f"))  // false
 val t = Fun("t", Fun("f", "t"))  // true
 val and = Fun("a", Fun("b", Ap(Ap("a", "b"),"a")))
 val or = Fun("a", Fun("b", Ap(Ap("a", "a"), "b")))
 val not = Fun("a", Fun("t", Fun("f", Ap(Ap("a","f"),"t"))))
+```
 
-/** 
-We can now write our own control structures, such as if/then/else 
-*/
+We can now write our own control structures, such as ``if/then/else``
+
+```scala mdoc:silent
 val ifthenelse = Fun("cond", Fun("t", Fun("f", Ap(Ap("cond", "t"), "f"))))
+```
 
-/**
-Church Encoding of Numbers
---------------------------
- 
-Let"s" now consider Numbers. We encode them as Peano numbers.  These encodings of numbers are often called _Church numbers_. 
-*/
+## Church Encoding of Numbers
+
+
+Let"s" now consider Numbers. We encode them as Peano numbers.  These encodings of numbers are often called _Church numbers_.
+
+```scala mdoc:silent
 val zero = Fun("s", Fun("z", "z"))
 val succ = Fun("n", Fun("s", Fun("z", Ap("s", Ap(Ap("n", "s"),"z")))))
 val one = Ap(succ, zero)
@@ -69,33 +69,44 @@ val add  = Fun("a", Fun("b", Fun("s", Fun("z", Ap(Ap("a","s"), Ap(Ap("b", "s"),"
 val mult = Fun("a", Fun("b", Fun("s", Fun("z", Ap(Ap("a", Ap("b","s")), "z")))))
 val exp  = Fun("a", Fun("b", Ap(Ap("b", Ap(mult, "a")), one)))
 val iszero = Fun("a", Ap(Ap("a", Fun("x", f)), t))
-/** 
-The predecessor function is more complicated (why?). We do not show it here. 
-For testing, here is a function that prints a unary representation of a number. */
-val printnum = Fun("a", Ap(Ap("a", Fun("x", PrintDot())), f))
+```
 
-/** 
-Church encoding of lists
-------------------------
+The predecessor function is more complicated (why?). We do not show it here.
+For testing, here is a function that prints a unary representation of a number.
+
+```scala mdoc:silent
+val printnum = Fun("a", Ap(Ap("a", Fun("x", PrintDot())), f))
+```
+
+## Church encoding of lists
+
 Again straightforward, except "tail", which we do not show here. It needs the same kind of trick (called "pairing trick")
-as the predecessor function. 
-*/
+as the predecessor function.
+
+```scala mdoc:silent
 val emptylist = Fun("c", Fun("e", "e"))
 val cons = Fun("h", Fun("r", Fun("c", Fun("e", Ap(Ap("c", "h"), Ap(Ap("r","c"),"e"))))))
 val head = Fun("l", Ap(Ap("l", Fun("h", Fun("t", "h"))), f))
+```
 
-/** 
-For instance, we can multiply all numbers in a list 
-*/
+For instance, we can multiply all numbers in a list
+
+```scala mdoc:silent
 val multlist = Fun("l", Ap(Ap("l", mult), one))
-/* Here is the list 3,2,3 */
+```
+
+Here is the list 3,2,3:
+
+```scala mdoc:silent
 val list323 = Ap(Ap(cons, three), Ap(Ap(cons, two), Ap(Ap(cons,three),emptylist)))
 
-val test = Ap(printnum, Ap(multlist, list323))
-/* Calling exec should yield 18 dots before the dummy result */
-def exec = eval(test, Map.empty) 
+```
 
-/** 
-Topic for class discussion: Can we do these encodings directly in Scala or Haskell? 
-*/
+```scala mdoc:silent
+val test = Ap(printnum, Ap(multlist, list323))
+// Calling exec should yield 18 dots before the dummy result
+def exec = eval(test, Map.empty)
+```
+
+Topic for class discussion: Can we do these encodings directly in Scala or Haskell?
 ```

--- a/src/14-object-algebras/object-algebras.md
+++ b/src/14-object-algebras/object-algebras.md
@@ -1,16 +1,17 @@
 # Object Algebras
 The content of this chapter is available as a Scala file [here.](./object-algebras.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.language.implicitConversions
+```
+Object algebras: A practical way of using Church Encodings
 
-/* Object algebras: A practical way of using Church Encodings */
 
-/* 
 Let's look at a Scala version of the Church encodings we saw for the lambda
-calculus. We use objects instead of functions, but otherwise 
-it is the same. Let's start with booleans. */
+calculus. We use objects instead of functions, but otherwise
+it is the same. Let's start with booleans.
 
+```scala mdoc
 trait Bool {
   def ifthenelse[T](t: T, e: T) : T
 }
@@ -22,12 +23,14 @@ case object F extends Bool {
   def ifthenelse[T](t: T, e: T) = e
 }
 def and(a: Bool, b: Bool) : Bool = a.ifthenelse(b,a)
+```
 
-/* In Smalltalk and related languages, booleans are actually implemented 
-like that (at least conceptually). 
+In Smalltalk and related languages, booleans are actually implemented
+like that (at least conceptually).
+
 In the same way, we can encode Church numerals.
-*/
 
+```scala mdoc
 trait NumC {
   def fold[T](z : T, s: T => T) : T
 }
@@ -46,66 +49,83 @@ def plus(a: NumC, b: NumC) = {
     }
   }
 }
+```
 
+```scala mdoc:silent
 val oneC = Succ(Zero)
 val twoC = Succ(oneC)
 val threeC = Succ(twoC)
 
 def testplusC = plus(twoC,threeC).fold[Unit]( (), _ => print("."))
+```
 
-/*
+
 Object algebras are a different way to do Church encodings
 in object-oriented languages. This is what the encoding
 of Church numbers looks like in object algebra style.
-*/
 
 
+```scala mdoc
 trait NumSig[T] {
   def z : T
   def s(p: T) : T
 }
 
-trait Num { def apply[T](x: NumSig[T]) : T }
+trait Num {
+  def apply[T](x: NumSig[T]) : T
+}
+```
 
-/* In other words, every constructor of data type is turned into
+In other words, every constructor of data type is turned into
 a function of the NumSig type, whereby recursive occurences are replaced
-by the type constructor T. Actual numbers have the type Num, i.e.,
-they are basically functions of type NumSig[T] => T.
+by the type constructor T.
+Actual numbers have the type Num, i.e., they are basically functions of type NumSig[T] => T.
+
+
 In the terminology of universal algebra, NumSig is an algebraic
 signature, and NumSig[T] => T is the type of algebras for that signature.
 Compared to the Church encoding above, we bundle the arguments of the
 fold function into a trait NumSig and pass them as a single object.
 The advantage of this encoding is that we can extend the set of parameters
 of the fold by using inheritance.
-In this encoding, the plus function looks like this: */
 
+In this encoding, the plus function looks like this:
+
+```scala mdoc
 def plus(a: Num, b: Num) = new Num {
   def apply[T](x: NumSig[T]) : T = a( new NumSig[T] {
     def z = b(x)
     def s(p:T) = x.s(p)
   })
 }
+```
 
-/* Here is the representation of some numbers. */
+Here is the representation of some numbers.
+
+```scala mdoc:silent
 val zero : Num = new Num { def apply[T](x: NumSig[T]) = x.z }
 val one : Num = new Num { def apply[T](x: NumSig[T]) = x.s(x.z) }
 val two : Num = new Num { def apply[T](x: NumSig[T]) = x.s(one(x)) }
 val three : Num = new Num { def apply[T](x: NumSig[T]) = x.s(two(x)) }
+```
 
-/* This is an interpretation of the Num "language" as Scala integers. */
+This is an interpretation of the Num "language" as Scala integers:
+
+```scala mdoc
 object NumAlg extends NumSig[Int] {
   def z = 0
   def s(x : Int ) = x+1
 }
+```
 
+```scala mdoc:silent
 val testplus = plus(two, three)(NumAlg) // yields 5
+```
 
-/*
 Let's look at a more useful application of object algebras. We encode
 expression trees as object algebras.
-*/
 
-
+```scala mdoc
 trait Exp[T] {
   implicit def id(name: String) : T
   def fun(param: String, body: T): T
@@ -114,16 +134,22 @@ trait Exp[T] {
   def add(e1: T, e2: T) : T
   def wth(x: String, xdef: T, body: T) : T = ap(fun(x,body),xdef)
 }
+```
 
-/* The structure of expression forces compositional interpretations. Hence
+The structure of expression forces compositional interpretations. Hence
 we use the compositional interpretation using meta-level closures to represent
-closures. */
+closures.
+
+```scala mdoc
 sealed abstract class Value
 type Env = Map[String, Value]
 case class ClosureV(f: Value => Value) extends Value
 case class NumV(n: Int) extends Value
+```
 
-/* An interpretation of expressions is now an implementation of the Exp interface */
+An interpretation of expressions is now an implementation of the Exp interface
+
+```scala mdoc
 trait eval extends Exp[Env => Value] {
   def id(name: String) = env => env(name)
   def fun(param: String, body: Env => Value) = env => ClosureV(v => body(env + (param -> v)))
@@ -137,21 +163,30 @@ trait eval extends Exp[Env => Value] {
     case _ => sys.error("can only add numbers")
   }
 }
-object eval extends eval
 
-/* An example program becomes a function that is parametric in the choosen interpretation */
+object eval extends eval
+```
+
+An example program becomes a function that is parametric in the choosen interpretation:
+
+```scala mdoc
 def test[T](semantics : Exp[T]) = {
   import semantics._
-  
+
   ap(ap(fun("x",fun("y",add("x","y"))),5),3)
 }
+```
 
-/* We evaluate the program by folding the eval visitor over it. */
+We evaluate the program by folding the eval visitor over it.
+
+```scala mdoc:silent
 val testres = test(eval)(Map.empty)
+```
 
-/* The object algebra encoding of expressions is quite extensible. For instance, we can
-add another case to the expression datatype by extending the interface. */
+The object algebra encoding of expressions is quite extensible. For instance, we can
+add another case to the expression datatype by extending the interface.
 
+```scala mdoc
 trait ExpWithMult[T] extends Exp[T] {
   def mult(e1 : T, e2: T) : T
 }
@@ -166,19 +201,23 @@ object evalWithMult extends evalWithMult
 
 def testMult[T](semantics : ExpWithMult[T]) = {
   import semantics._
-  
+
   ap(ap(fun("x",fun("y",mult("x","y"))),5),3)
 }
+```
 
+```scala mdoc:silent
 val testresMult = testMult(evalWithMult)(Map.empty)
+```
 
-/* Note that there is no danger of confusing the language variants. For instance,
-an attempt to pass testMult to eval will be a static type error. */
+Note that there is no danger of confusing the language variants. For instance,
+an attempt to pass testMult to eval will be a static type error.
 
-/* We can also go one step further and combine object algebras with 
-typed higher-order abstract syntax, using higher-kinded type members. 
-Don't panic if you don't understand what is going on here. 
-*/
+We can also go one step further and combine object algebras with
+typed higher-order abstract syntax, using higher-kinded type members.
+Don't panic if you don't understand what is going on here.
+
+```scala mdoc
 trait ExpT {
   type Rep[_]
   def fun[S,T](f : Rep[S] => Rep[T]): Rep[S=>T]
@@ -186,10 +225,13 @@ trait ExpT {
   implicit def num(n: Int) : Rep[Int]
   def add(e1: Rep[Int], e2: Rep[Int]) : Rep[Int]
 }
+```
 
-/* Note that, in contrast to eval, no dynamic checks (match ...) are needed
+Note that, in contrast to eval, no dynamic checks (match ...) are needed
 in the interpreter. This is because the ExpT datatype guarantees well-typedness
-of expressions. */
+of expressions.
+
+```scala mdoc
 object evalT extends ExpT {
   type Rep[X] = X
   def fun[S,T](f: S=>T) =f
@@ -215,18 +257,23 @@ def test2(semantics: ExpT) = {
   import semantics._
   ap(ap(fun((x:Rep[Int])=>fun((y:Rep[Int])=>add(x,y))),5),3)
 }
+```
 
+```scala mdoc:silent
 val testres2 = test2(evalT)
 val testres3 = test2(prettyprintT)
+```
 
-/* An attempt to construct an ill-formed object program will be detected by
-the Scala type checker. For instance, the following program which adds 
-a number and a function is rejected by the Scala type checker: 
+An attempt to construct an ill-formed object program will be detected by
+the Scala type checker. For instance, the following program which adds
+a number and a function is rejected by the Scala type checker:
+
+```scala mdoc:fail
 def testilltyped(semantics: ExpT) = {
   import semantics._
   add(5,fun((x: Rep[Int]) => x))
 }
+```
+
 References:
 B. Olivira, W.Cook. Extensibility for the Masses: Practical Extensibility with Object Algebras. Proc. ECOOP 2012.
-*/
-```


### PR DESCRIPTION
I reordered chapter 10-14. However there was a problem in mutation.md, as I had to render a big block of scala code with comments, because its enclosed by a ``match`` block and rendering single ``case``blocks leads to an enumaration error.

You can find the block in mutation.md, on line 159 to 249:


```scala mdoc
def eval(e: Exp, env: Env, s: Store) : (Value, Store) = e match {
  /* All expressions whose evaluation does not alter the store just return s. */
  case Num(n) => (NumV(n), s)
  case Id(x) => (env(x), s)
  case f@Fun(_, _) => (ClosureV(f, env), s)


// In recursive cases we have to thread the store through the evaluation. In particular, we define the order of evaluation
// explicitly through data flow dependencies.

  case If0(cond, thenExp, elseExp)
    => eval(cond, env, s) match {
         case (NumV(0), s1) => eval(thenExp, env, s1)
         case (_, s1)       => eval(elseExp, env, s1)

         /* An alternative that enfoces runtime type-correctness of
          * the conditional expression:
         case (NumV(_), s1) => eval(elseExp, env, s1)
         case _             => sys.error("can only test if a number is 0") */
       }

  case Add(l, r)
    => eval(l, env, s) match {
         case (NumV(v1), s1)
           => eval(r, env, s1) match {
                case (NumV(v2), s2) => (NumV(v1 + v2), s2)
                case _ => sys.error("can only add numbers")
              }
         case _
           => sys.error("can only add numbers")
       }

  case Mul(l, r)
    => eval(l, env, s) match {
         case (NumV(v1), s1)
           => eval(r, env, s1) match {
                case (NumV(v2), s2) => (NumV(v1 * v2), s2)
                case _ => sys.error("can only multiply numbers")
              }
         case _ => sys.error("can only multiply numbers")
       }

  case Ap(f, a)
    => eval(f, env, s) match {
         case (ClosureV(f, closureEnv), s1)
           => eval(a, env, s1) match {
                case (av, s2)
                  => eval(f.body, closureEnv + (f.param -> av), s2)
              }
         case _ => sys.error("can only apply functions")
       }


// In a sequence, we ignore the result of evaluating e1 but not its effect on the store.

  case Seq(e1, e2) => eval(e2, env, eval(e1, env, s)._2)

//  A new box is created by putting it into the store at a new address.

  case NewBox(e: Exp)
    => eval(e, env, s) match {
         case (v, s1) => {
           val a = nextAddress
           (AddressV(a), s1 + (a -> v))
         }
       }

// Setting a box is now a two-step process: First evaluate b to an
// address, then lookup and update the value associated to the
// address in the store. Note that "updated" is a functional method.

  case SetBox(b: Exp, e: Exp)
    => eval(b, env, s) match {
         case (AddressV(a), s1)
           => eval(e, env, s1) match {
                case (ev, s2) => (ev, s2.updated(a, ev))
              }
         case _ => sys.error("can only set boxes")
       }

// OpenBox uses the same two-step process but does not update the
// store.

  case OpenBox(b: Exp)
    => eval(b, env, s) match {
         case (AddressV(a), s1) => (s1(a), s1)
         case _                 => sys.error("can only open boxes")
       }
}
```

For now I leave it as it is, if you got any recommendations how to handle this, I`d be happy to know :)