### PR TITLE
Chapters 15-20 reordered

### DIFF
--- a/src/15-continuations-1/continuations-1.md
+++ b/src/15-continuations-1/continuations-1.md
@@ -2,15 +2,13 @@
 
 The content of this chapter is available as a Scala file [here.](./continuations-1.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.io.StdIn.readLine
-/*
-Continuations
-=============
-*/
+```
 
+Consider the following very simple program:
 
-/* Consider the following very simple program. */
+```scala mdoc
 def inputNumber(prompt: String): Int = {
   println(prompt)
   Integer.parseInt(readLine())
@@ -18,32 +16,38 @@ def inputNumber(prompt: String): Int = {
 def progSimple = {
   println(inputNumber("First number:" ) + inputNumber("Second number"))
 }
-/* Now consider a web version of the program:
- * - the first number is entered on the first page
- * - then the first number is submitted, a form to enter the second number is shown
- * - when the second number is submitted, a form with the result is generated and shown.
- *
- * Even this "addition server" is difficult to implement. Because http is a stateless protocol (for good reasons),
- * every web program is basically forced to terminate after every request. This means that
- * the Web developer must turn this application into three programs:
- * (a) The first program displays the first form.
- * (b) The second program consumes the form values from the first form, and generates the second form.
- * (c) The third program consumes the form values from the second form, computes the output, and
- * generates the result.
- *
- * Because the value entered in the first form is needed by the third program to compute its output, this
- * value must somehow be transmitted between from the first program to the third. This is typically done
- * by using the hidden field mechanism of HTML.
- *
- * Suppose, instead of using a hidden field, the application developer used a Java Servlet session object,
- * or a database field, to store the first number. (Application developers are often pushed to do this
- * because that is the feature most conveniently supported by the language and API they are employing.)
- * Then, if the developer were to exploratorily open multiple windows
- * the application can compute the wrong answer.
- * Hence, the actual program in a web developer's mind has the structure of the following program.
- * An actual web program is of course more complicated, but this primitive model of web
- * programming is sufficient to explain the problem. */
+```
 
+Now consider a web version of the program:
+
+- the first number is entered on the first page
+- then the first number is submitted, a form to enter the second number is shown
+- when the second number is submitted, a form with the result is generated and shown.
+
+ Even this "addition server" is difficult to implement. Because http is a stateless protocol (for good reasons),
+ every web program is basically forced to terminate after every request. This means that
+ the Web developer must turn this application into three programs:
+
+ (a) The first program displays the first form.
+ (b) The second program consumes the form values from the first form, and generates the second form.
+ (c) The third program consumes the form values from the second form, computes the output, and
+
+ generates the result.
+
+ Because the value entered in the first form is needed by the third program to compute its output, this
+ value must somehow be transmitted between from the first program to the third. This is typically done
+ by using the hidden field mechanism of HTML.
+
+ Suppose, instead of using a hidden field, the application developer used a Java Servlet session object,
+ or a database field, to store the first number. (Application developers are often pushed to do this
+ because that is the feature most conveniently supported by the language and API they are employing.)
+ Then, if the developer were to exploratorily open multiple windows
+ the application can compute the wrong answer.
+ Hence, the actual program in a web developer's mind has the structure of the following program.
+ An actual web program is of course more complicated, but this primitive model of web
+ programming is sufficient to explain the problem.
+
+```scala mdoc
 def webdisplay(s: String) : Nothing = { // we use the return type "Nothing" for functions that will never return (normally)
   println(s)
   sys.error("program terminated")
@@ -58,39 +62,49 @@ def webread(prompt: String, continue: String) : Nothing = {
 def program1 = webread("enter first number", "s2")
 def program2(n1: Int) = webread("enter second number and remind me of previoulsy entered number "+n1, "s3")
 def program3(n1: Int, n2: Int) = webdisplay("The sum of "+ n1 + " and "+n2+ " is "+(n1+n2))
+```
 
-/* We could write a better webread and webdisplay procedure if we could somehow get hold of the
- * pending computation at the time when the procedure was invoked. Such a pending computation is
- * called _continuation_.
- *
- * Let's consider the continuation at the point of the first interaction in the original program,
- *
+ We could write a better webread and webdisplay procedure if we could somehow get hold of the
+ pending computation at the time when the procedure was invoked. Such a pending computation is
+ called _continuation_.
+
+ Let's consider the continuation at the point of the first interaction in the original program,
+
+```
   def prog = {
     println(inputNumber() + inputNumber())
   }
- *
- * The pending computation (or, continuation in the following) is to take the result of the first
- * inputNumber invocation, add to it the result of the second invocation, and display it.
- * We can express the continuation as a function: */
+```
 
+ The pending computation (or, continuation in the following) is to take the result of the first
+ inputNumber invocation, add to it the result of the second invocation, and display it.
+
+ We can express the continuation as a function:
+
+```scala mdoc:silent
 val cont1 = (n: Int) => println(n + inputNumber("Second number"))
+```
 
-/* Similarly, the continuation at the second point of interaction is:
- * val cont2 = (m: Int) => println(n+m)
- * where n is the result of the first input, which is stored in the closure of cont2
- *
- * Assuming an explicit representation of the continuation, it is obvious that we can now
- * write a version of webread, called webread_k, which takes the continuation as second parameter and invokes
- * the continuation once the answer to the result is received by the server.
- * This can be implemented, say, by associating to a continatuion a unique ID, store the continuation
- * in a hashmap on the server using this ID, and storing the ID in the form such that it gets
- * submitted back to the server once the client presses the submit button.
- *
- * Here is code illustrating the idea. For simplicity we assume that all web forms return
- * a single integer value.
- */
+ Similarly, the continuation at the second point of interaction is:
+
+ ```
+  val cont2 = (m: Int) => println(n+m)
+```
+
+ where n is the result of the first input, which is stored in the closure of cont2
+
+ Assuming an explicit representation of the continuation, it is obvious that we can now
+ write a version of webread, called webread_k, which takes the continuation as second parameter and invokes
+ the continuation once the answer to the result is received by the server.
+ This can be implemented, say, by associating to a continatuion a unique ID, store the continuation
+ in a hashmap on the server using this ID, and storing the ID in the form such that it gets
+ submitted back to the server once the client presses the submit button.
+
+ Here is code illustrating the idea. For simplicity we assume that all web forms return
+ a single integer value.
 
 
+```scala mdoc
 val continuations = new scala.collection.mutable.HashMap[Symbol, Int=>Nothing]()
 var nextIndex : Int = 0
 def getNextID = {
@@ -107,112 +121,132 @@ def webread_k(prompt: String, k: Int=>Nothing) : Nothing = {
 }
 
 def continue(kid: Symbol, result: Int) = continuations(kid)(result)
+```
 
-/* Using webread_k, we can now define our addition server as follows.
- * If you try prog, ignore the stack traces.
- */
+ Using webread_k, we can now define our addition server as follows.
+ If you try prog, ignore the stack traces.
 
+```
 def webprog = webread_k("enter first number", (n) =>
              webread_k("enter second number", (m) => webdisplay("The sum of "+n+ " and "+m+ " is "+(n+m))))
+```
 
-/* For instance, try:
- * scala> webprog          -- yields some continuation id 'c1
- * scala> continue('c1,5)   -- yields some continuation id 'c2
- * scala> continue('c2,7)
- *
- * This should yield the result 12 as expected. But also try:
- * scala> webprog          -- yields some continuation id 'c1
- * scala> contine('c1,5)    -- yields some continuation id 'c2
- * scala> contine('c1,6)    -- yields some continuation id 'c3
- * scala> continue('c2,3)   -- should yield 8
- * scala> continue('c3,3)   -- should yield 9
- *
- * The style of programming in webprog, which is obviously more complicated than the logical
- * structure of progSimple, shows up in many practical programming scenarios - server-side web programming
- * is just one of them. For instance, in JavaScript many API functions for asynchronous communication
- * such as httprequest in AJAX require to pass a callback function, which leads to similar code
- * as the one in webprog above.
- *
- * Let's consider this "web transformation" - the transformation from progSimple to webprog - in more detail.
- * To this purpose, let's make our application a bit more sophisticated. Instead of entering only two
- * numbers, the user enters n numbers, e.g., the prices of a list of n items.
- *
- * Here is the "non-web" version of the application:
- */
+For instance, try:
+```
+   scala> webprog          -- yields some continuation id 'c1
+   scala> continue('c1,5)   -- yields some continuation id 'c2
+  scala> continue('c2,7)
 
+  This should yield the result 12 as expected. But also try:
+  scala> webprog          -- yields some continuation id 'c1
+  scala> contine('c1,5)    -- yields some continuation id 'c2
+  scala> contine('c1,6)    -- yields some continuation id 'c3
+  scala> continue('c2,3)   -- should yield 8
+  scala> continue('c3,3)   -- should yield 9
+```
+
+ The style of programming in webprog, which is obviously more complicated than the logical
+ structure of progSimple, shows up in many practical programming scenarios - server-side web programming
+ is just one of them. For instance, in JavaScript many API functions for asynchronous communication
+ such as httprequest in AJAX require to pass a callback function, which leads to similar code
+ as the one in webprog above.
+
+ Let's consider this "web transformation" - the transformation from progSimple to webprog - in more detail.
+ To this purpose, let's make our application a bit more sophisticated. Instead of entering only two
+ numbers, the user enters n numbers, e.g., the prices of a list of n items.
+
+ Here is the "non-web" version of the application:
+
+```scala mdoc
 def allCosts(itemList: List[String]) : Int = itemList match {
    case Nil => 0
    case x :: rest => inputNumber("Cost of item "+x+ ":") + allCosts(rest)
 }
+```
+
+```scala mdoc:silent
 val testData : List[String] = List("banana", "apple", "orange")
 
 def test = println("Total sum: "+allCosts(testData))
+```
 
-/* This version of allCosts is clearly not web-friendly, because it uses inputNumber,
- * which we do not know how to implement for the web.
- *
- * The first thing to observe is that on its own, allCosts is not a complete program: it doesn't do anything unless
- * it is called with actual parameters!
- * Instead, it is a library procedure that may be used in many different contexts. Because it has a Web interaction,
- * however, there is the danger that at the point of interaction, the rest of the computation --- that is, the
- * computation that invoked allCosts --- will be lost. To prevent this, allCosts must consume an extra argument,
- * a continuation, that represents the rest of the pending computation. To signify this change in contract, we will use
- * the convention of appending _k to the name of the procedure and k to name the continuation parameter.
- */
+ This version of allCosts is clearly not web-friendly, because it uses inputNumber,
+ which we do not know how to implement for the web.
 
-/* Here is a first attempt to define allCosts_k.
- *
+ The first thing to observe is that on its own, allCosts is not a complete program: it doesn't do anything unless
+ it is called with actual parameters!
+ Instead, it is a library procedure that may be used in many different contexts. Because it has a Web interaction,
+ however, there is the danger that at the point of interaction, the rest of the computation --- that is, the
+ computation that invoked allCosts --- will be lost. To prevent this, allCosts must consume an extra argument,
+ a continuation, that represents the rest of the pending computation. To signify this change in contract, we will use
+ the convention of appending _k to the name of the procedure and k to name the continuation parameter.
+
+
+ Here is a first attempt to define ``allCosts_k``.
+
+```scala
  def allCosts_k(itemList: List[String], k: Int => Nothing) : Nothing = itemList match {
    case Nil => 0
    case x :: rest => webread_k("Cost of item "+x+":", n => n+allCosts_k(rest,k))
 }
- * This may look reasonable, but it suffers from an immediate problem. When the recursive call occurs, if
- * the list had two or more elements, then there will immediately be another Web interaction. Because this will
- * terminate the program, the pending addition will be lost! Therefore, the addition of n has to move into the
- * continuation fed to allCosts_k. In code:
+```
+
+ This may look reasonable, but it suffers from an immediate problem. When the recursive call occurs, if
+ the list had two or more elements, then there will immediately be another Web interaction. Because this will
+ terminate the program, the pending addition will be lost! Therefore, the addition of n has to move into the
+ continuation fed to ``allCosts_k``. In code:
+
+ ```scala mdoc
 def allCosts_k(itemList: List[String], k: Int => Nothing) : Nothing = itemList match {
    case Nil => 0
    case x :: rest => webread_k("Cost of item "+x+":", n => allCosts_k(rest,m => k(m+n)))
 }
- * That is, the receiver of the Web interaction is invoked with the cost of the first item. When allCosts_k is invoked
- * recursively, it is applied to the rest of the list. Its receiver must therefore receive the tally of costs of the
- * remaining items. That explains the pattern in the receiver.
- *
- * The only problem is, where does a continuation ever get a value? We create larger-and-larger continuation on
- * each recursive invocation, but what ever invokes them?
- *
- * Here is the same problem from a different angle (that also answers the question above). Notice that each
- * recursive invocation of allCosts_k takes place in the aftermath of a Web interaction. We have already seen how
- * the act of Web interaction terminates the pending computation. Therefore, when the list empties, where
- * is the value 0 going? Presumably to the pending computation, but there is none. Any computation that
- * would have been pending has now been recorded in k, which is expecting a value. Therefore, the correct
- * transformation of this procedure is:
- */
+```
 
+ That is, the receiver of the Web interaction is invoked with the cost of the first item. When allCosts_k is invoked
+ recursively, it is applied to the rest of the list. Its receiver must therefore receive the tally of costs of the
+ remaining items. That explains the pattern in the receiver.
+
+ The only problem is, where does a continuation ever get a value? We create larger-and-larger continuation on
+ each recursive invocation, but what ever invokes them?
+
+ Here is the same problem from a different angle (that also answers the question above). Notice that each
+ recursive invocation of allCosts_k takes place in the aftermath of a Web interaction. We have already seen how
+ the act of Web interaction terminates the pending computation. Therefore, when the list empties, where
+ is the value 0 going? Presumably to the pending computation, but there is none. Any computation that
+ would have been pending has now been recorded in k, which is expecting a value. Therefore, the correct
+ transformation of this procedure is:
+
+```scala mdoc
 def allCosts_k(itemList: List[String], k: Int => Nothing) : Nothing = itemList match {
    case Nil => k(0)
    case x :: rest => webread_k("Cost of item "+x+ ":", n => allCosts_k(rest,m => k(m+n)))
 }
 
 def testweb = allCosts_k(testData, m => webdisplay("Total sum: "+m))
+```
 
-/* Let's now consider the case that we have used a library function for the iteration in allCosts, namely
- * the map function, which we replicate here. */
+ Let's now consider the case that we have used a library function for the iteration in allCosts, namely
+ the map function, which we replicate here.
+
+ ```scala mdoc
  def map[S,T](c: List[S], f: S=>T) : List[T] = c match {
    case Nil => Nil
    case x :: rest => f(x) :: map(rest,f)
 }
 /* Using map, we can rephrase allCosts as follows. */
 def allCosts2(itemList: List[String]) : Int = map(itemList, (x:String) => inputNumber("Cost of item "+x+ ":")).sum
+```
 
-/* What if we we want to use map in allCosts_k?
- *
- * Just using webread_k in place of inputNumber will not work, since webread_k expects an additional parameter.
- * Obviously we must somehow modify the definition of map. But what can we pass as second parameter in the call
- * to f?
- *
- * Insight: We must perform the "web transformation" to map as well. We call the reslt map_k. Here is the code: */
+ What if we we want to use map in allCosts_k?
 
+ Just using ``webread_k`` in place of ``inputNumber`` will not work, since ``webread_k`` expects an additional parameter.
+ Obviously we must somehow modify the definition of map. But what can we pass as second parameter in the call
+ to f?
+
+ __Insight__: We must perform the "web transformation" to map as well. We call the result ``map_k``. Here is the code:
+
+```scala mdoc
 def map_k[S,T](c: List[S], f: (S,T=>Nothing) => Nothing, k: List[T] => Nothing) : Nothing = c match {
    case Nil => k(Nil)
    case x :: rest => f(x, t => map_k(rest, f, (tr:List[T]) => k(t::tr)))
@@ -221,27 +255,27 @@ def map_k[S,T](c: List[S], f: (S,T=>Nothing) => Nothing, k: List[T] => Nothing) 
 def allCosts2_k(itemList: List[String], k: Int => Nothing) : Nothing =
    map_k(itemList, (x:String,k2:Int=>Nothing) => webread_k("Cost of item "+x+ ":", k2),(l:List[Int]) => k(l.sum))
 
-/* Implications of the "web transformation":
- *
- * 1. We have had to make decisions about the order of evaluation. That is, we had to choose whether
- * to evaluate the left or the right argument of addition first. This was an issue we had specified only
- * implicitly earlier; if our evaluator had chosen to evaluate arguments right-to-left, the Web program at
- * the beginning of this document would have asked for the second argument before the first! We have
- * made this left-to-right order of evaluation explicit in our transformation.
- *
- * 2. The transformation we use is global, namely it (potentially) affects all the procedures in the program
- * by forcing them all to consume an extra continuation as an argument. We usually don't have a choice as
- * to whether or not to transform a procedure. Suppose f invokes g and g invokes h, and we transform
- * f to f_k but don't transform g or h. Now when f_k invokes g and g invokes h, suppose h consumes
- * input from the Web. At this point the program terminates, but the last continuation procedure (necessary
- * to resume the computation when the user supplies an input) is the one given to f_k, with all record of
- * g and h lost.
- *
- * 3. This transformation sequentializes the program. Given a nested expression, it forces the programmer
- * to choose which sub-expression to evaluate first (a consequence of the first point above); further, every
- * subsequent operation lies in the continuation, which in turn picks the first expression to evaluate, pushing
- * all other operations into its continuation; and so forth. The net result is a program that looks an awful lot
- * like a traditional procedural program. This suggests that this series of transformations can be used to
- * compile a program in a language like Scheme into one in a language like C!
- */
 ```
+
+## Implications of the "web transformation":
+
+ 1. We have had to make decisions about the order of evaluation. That is, we had to choose whether
+ to evaluate the left or the right argument of addition first. This was an issue we had specified only
+ implicitly earlier; if our evaluator had chosen to evaluate arguments right-to-left, the Web program at
+ the beginning of this document would have asked for the second argument before the first! We have
+ made this left-to-right order of evaluation explicit in our transformation.
+
+ 2. The transformation we use is global, namely it (potentially) affects all the procedures in the program
+ by forcing them all to consume an extra continuation as an argument. We usually don't have a choice as
+ to whether or not to transform a procedure. Suppose f invokes g and g invokes h, and we transform
+ f to f_k but don't transform g or h. Now when f_k invokes g and g invokes h, suppose h consumes
+ input from the Web. At this point the program terminates, but the last continuation procedure (necessary
+ to resume the computation when the user supplies an input) is the one given to f_k, with all record of
+ g and h lost.
+
+ 3. This transformation sequentializes the program. Given a nested expression, it forces the programmer
+ to choose which sub-expression to evaluate first (a consequence of the first point above); further, every
+ subsequent operation lies in the continuation, which in turn picks the first expression to evaluate, pushing
+ all other operations into its continuation; and so forth. The net result is a program that looks an awful lot
+ like a traditional procedural program. This suggests that this series of transformations can be used to
+ compile a program in a language like Scheme into one in a language like C!

--- a/src/16-continuations-2/continuations-2.md
+++ b/src/16-continuations-2/continuations-2.md
@@ -2,72 +2,110 @@
 
 The content of this chapter is available as a Scala file [here.](./continuations-2.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.language.implicitConversions
+```
+Today's goal is to make the "web" (or rather, CPS) transformation which we applied informally
+in the previous lecture formal.
 
-/* Today's goal is to make the "web" (or rather, CPS) transformation which we applied informally
-  in the previous lecture formal.
-  In the previous lecture we have seen that we had to translate the following program:
-  println("The sum is: "+ (inputNumber("First number:" ) + inputNumber("Second number")))
-  into this program:
+In the previous lecture we have seen that we had to translate the following program:
+
+```
+println("The sum is: "+ (inputNumber("First number:" ) + inputNumber("Second number")))
+```
+
+into this program:
+
+```
   webread_k("First number", (n) =>
              webread_k("Second number:", (m) => webdisplay("The sum is: "+(n+m))))
-  This hand-translation is sufficient if this expression is the entire program.
-  If we wish to use it as a sub-expression in a larger program, this does not suffice,
-  because there may be a pending computation outside its own evaluation. For that
-  reason, the program has to send its result to a continuation instead of returning it:
+```
+
+This hand-translation is sufficient if this expression is the entire program.
+If we wish to use it as a sub-expression in a larger program, this does not suffice,
+because there may be a pending computation outside its own evaluation. For that
+reason, the program has to send its result to a continuation instead of returning it:
+
+```
   k => webread_k("First number", (n) =>
              webread_k("Second number:", (m) => webdisplay("The sum is: "+k(n+m))))
-  This version can be employed in the transformation of a larger program. In the special
-  case where this is the entire program we can apply the transformed term to the identity
-  function to get the same result as the previous manual transformation.
-  In general, every term, when converted to CPS, will be have the following properties
-  (see O. Danvy, Three Steps for the CPS Transformation, 1991):
+```
+
+This version can be employed in the transformation of a larger program. In the special
+case where this is the entire program we can apply the transformed term to the identity
+function to get the same result as the previous manual transformation.
+
+In general, every term, when converted to CPS, will be have the following properties
+(see O. Danvy, Three Steps for the CPS Transformation, 1991):
+
   1) The values of all intermediate applications are given a name
+
   2) The evaluation of these applications is sequentialized based on a traversal of their
      abstract syntax tree.
+
   3) The results of the transformation are procedures that expect a continuation parameter -
      a lambda abstraction whose application to intermediate values yields the final result
      of the whole evaluation.
+
   Let us now look at the transformation of a function application. For instance, let us
   consider the term
+  ```
     f(a)(g(b))
-  The transformation of the function argument, f(a), should be
-    f_k(a, fval => ...)
+  ```
+  The transformation of the function argument, ``f(a)``, should be
+
+    ``f_k(a, fval => ...)``
+
   Similarly, the transformation of the argument position would be:
-    g_k(b, aval => ...)
+
+    ``g_k(b, aval => ...)``
+
   Given these two values, fval and aval, we can now perform the application, like so:
-    k(fval(aval))
-  However, this will not work, because if fval makes a web interaction itself it will not return.
+
+    ``k(fval(aval))``
+
+  However, this will not work, because if ``fval`` makes a web interaction itself it will not return.
   Instead, k must be given as an argument to the function, like so:
-    k => f_k(a, fval => g_k(b, aval => fval(aval,k)))
+
+  ``  k => f_k(a, fval => g_k(b, aval => fval(aval,k)))``
+
   Reading this sequentially, it says to evaluate the function expression, store its value in fval,
   then evaluate the argument, store its value in aval, and finally invoke the function on the argument.
   This function's continuation is the same as that of the function application itself.
   What about variables and constants? Since every term in CPS must be a function that consumes a continuation,
-  the constant is simply send to the continuation. For instance, the CPS transformation of
-  the number 3 is k => k(3)
-  What about function definitions, such as x => x ? Since every lambda expression is also a constant,
+  the constant is simply send to the continuation.
+
+  For instance, the CPS transformation of
+  the number 3 is ``k => k(3)``
+
+  What about function definitions, such as ``x => x`` ? Since every lambda expression is also a constant,
   we might be tempted to use the same rule as above, i.e.,
-    k => k(x => x)
+
+  ``  k => k(x => x)``
+
   However, the transformation is more subtle. A function application invokes the function on two arguments, whereas
   the original function x=>x consumes only one. What is the second argument?
-  Answer: It is the _dynamic_ continuation, i.e., the continuation at the time of the function _application_
+
+  __Answer__: It is the _dynamic_ continuation, i.e., the continuation at the time of the function _application_
   (as opposed to its definition). We cannot ignore this continuation: It is the stack active at the point
   of function invocation, so we want to preserve it. This is in contrast to what we did with environments,
-  and more in line with our treatment of the store. The transformed version hence reads:
-  k => k( (x,dynk) => (k => k(x))(dynk))
+  and more in line with our treatment of the store.
+
+  The transformed version hence reads:
+  ``k => k( (x,dynk) => (k => k(x))(dynk))``
   which is equivalent (when the inner application finally happens) to:
-  k => k( (x,dynk) => dynk(x))
+  ``k => k( (x,dynk) => dynk(x))``
+
   This is a function that accepts a value and a dynamic continuation and sends the value to that continuation.
   We are now ready to write this transformation formally, as a source-to-source transformation. This transformation
   could have the type cps(e: Exp): Exp, but we choose a different type for two reasons:
+
   1) In CPS we need function definitions and applications with two arguments instead of one. This could be addressed
      by adding new syntax.
+
   2) More importantly, we want the invariants of the CPS format to be clearly visible in the syntax definition of the
      result, most importantly the fact that all function applications are tail calls.
-  For this reason, we define a special new syntax for CPS-transformed terms. Here is our original syntax: */
-
+```scala mdoc
 enum Exp:
   case Num(n: Int)
   case Id(name: String)
@@ -78,19 +116,24 @@ enum Exp:
 object Exp:
   implicit def num2exp(n: Int): Exp = Num(n)
   implicit def id2exp(s: String): Exp = Id(s)
+```
 
+```scala mdoc:invisible
 import Exp._
+```
 
-/* For CPS transformed terms, we define two different syntactic categories: Values (CPSVal) and Expressions (CPSExp).
+For CPS transformed terms, we define two different syntactic categories: Values (CPSVal) and Expressions (CPSExp).
    By "values", we mean terms that "return", that is, terms that are different from applications of functions
    or continuations (neither of which returns). Additions (CPSAdd) are also values in this regard: We assume addition
    to be built-in and not requiring CPS-transformations.
+
    The syntax makes clear that all arguments of a function application are values - hence no nesting of applications
    can occur. Furthermore, the syntax differentiates between defining an ordinary function (CPSFun) which, when translated,
    gets an additional continuation parameter, and Continuation Functions (CPSCont), which are the result of the CPS
    transformation. Correspondingly, we have two different forms of applications, CPSContApp and CPSFunApp.
-   Here is the formal definition: */
 
+Here is the formal definition:
+```scala mdoc
 sealed abstract class CPSExp
 abstract class CPSVal extends CPSExp
 case class CPSNum(n: Int) extends CPSVal
@@ -102,13 +145,14 @@ implicit def id2cpsexp(x: String): CPSVar = CPSVar(x)
 case class CPSContAp(k: CPSVal, a: CPSVal) extends CPSExp
 case class CPSFunAp(f: CPSVar, a: CPSVar, k: CPSVar) extends CPSExp // the arguments are even CPSVar and not only CPSVal!
 case class CPSAdd(l: CPSVar, r: CPSVar) extends CPSVal
+```
 
-/* With these definitions, we are now ready to formalize the transformation described above.
- * There is one technical issues: We need to introduce new names for binders into our program, such as "k".
- * We need to make sure that we do not accidentially capture existing names in the program. For this
- * reason we need our freshName machinery we introduced in 5-fae.scala.
- */
+With these definitions, we are now ready to formalize the transformation described above.
+There is one technical issues: We need to introduce new names for binders into our program, such as "k".
+We need to make sure that we do not accidentially capture existing names in the program.
+For this reason we need our ``freshName`` machinery we introduced in 5-fae.scala.
 
+```scala mdoc
 def freeVars(e: Exp) : Set[String] =  e match {
    case Id(x) => Set(x)
    case Add(l,r) => freeVars(l) ++ freeVars(r)
@@ -148,14 +192,19 @@ def cps(e: Exp) : CPSCont = e match {
      CPSCont(k, CPSContAp("k",CPSNum(n)))
    }
 }
+```
 
-/* This transformation is the so-called Fischer CPS transformation. There are many other CPS transformation algorithms.
+This transformation is the so-called Fischer CPS transformation. There are many other CPS transformation algorithms.
    The Fischer CPS transformation is nice because it is so simple and because it is defined as one simple structural
    recursion over the AST. Its main disadvantage is the existence of so-called "administrative redexes".
+
    An administrative redex is a function application whose operator is a "continuation lambda" - a lambda produced during
    CPS transformation that was not in the original program. Such function applications can be computed immediately because
    the function which is called is known.
-   For instance, cps(Add(2,3)) yields
+
+   For instance, ``cps(Add(2,3))`` yields
+
+```
    CPSCont("k",
            CPSContAp(
              CPSCont("k",
@@ -166,8 +215,8 @@ def cps(e: Exp) : CPSCont = e match {
                                CPSContAp("k",3)),
                        CPSCont("rv",
                                CPSAdd("rv","lv"))))))
-    instead of
-    CPSCont("k", CPSContAp("k", CPSAdd(2,3)))
-    Many more advanced CPS transformation algorithms try to avoid as many administrative redexes as possible.
-*/
 ```
+    instead of
+    ``CPSCont("k", CPSContAp("k", CPSAdd(2,3)))``
+    
+    Many more advanced CPS transformation algorithms try to avoid as many administrative redexes as possible.

--- a/src/17-first-class-continuations/first-class-continuations.md
+++ b/src/17-first-class-continuations/first-class-continuations.md
@@ -2,17 +2,16 @@
 
 The content of this chapter is available as a Scala file [here.](./first-class-continuations.scala)
 
-```scala mdoc
+```scala mdoc:invisible
 import scala.language.implicitConversions
+```
 
-/**
-First-Class Continuations
-=========================
+
 Today's goal is to formalize first-class continuations as illustrated by Scheme's let/cc construct. In the previous lecture we have
 learned why first class continuations are a powerful language construct. Today we learn the semantics of first-class continuations by
 extending our interpreter to support letcc. Here is the abstract syntax of the language extended with letcc:
-*/
 
+```scala mdoc
 enum Exp:
   case Num(n: Int)
   case Id(name: String)
@@ -25,23 +24,29 @@ enum Exp:
 object Exp:
   implicit def num2exp(n: Int): Exp = Num(n)
   implicit def id2exp(s: String): Exp = Id(s)
+```
 
+```scala mdoc:invisible
 import Exp._
+```
 
-/**
 But how do we implement letcc? How do we get hold of the rest of the computation of the object (=interpreted) program?
 One idea would be to CPS-transform the object program. Then we have the current continuation available and could store it in environments
 etc.
 However, we want to give a direct semantics to first-class continuations, without first  transforming the object program.
-Insight: If we would CPS-transform the interpreter, the continuation of the interpreter also represents, in some way, the continuation
+
+__Insight__: If we would CPS-transform the interpreter, the continuation of the interpreter also represents, in some way, the continuation
 of the object program. The difference is that it represents what's left to do in the interpreter and not in the object program.
 However, what is left in the interpreter _is_ what is left in the object program.
-Hence we are faced with two tasks:
-  1. CPS-transform the interpreter
-  2. add a branch for Letcc to the interpreter.
-Let's start with the standard infrastructure of values and environments.
-*/
 
+Hence we are faced with two tasks:
+
+  1. CPS-transform the interpreter
+  2. add a branch for ``Letcc`` to the interpreter.
+
+Let's start with the standard infrastructure of values and environments.
+
+```scala:mdoc
 sealed abstract class Value
 type Env = Map[String, Value]
 case class NumV(n: Int) extends Value
@@ -54,16 +59,17 @@ some other object language value:
 */
 
 case class ContV(f: Value => Nothing) extends Value
+```
 
-/**
 We also need a syntactic construct to apply continuations. One way to provide such a construct would be to add a new syntactic category
 of continuation application. We will instead do what Scheme and other languages also do: We overload the normal function applicaton
 construct and also use it for application of continuations.
+
 This means that we will need a case distinction in our interpreter whether the function argument is a closure or a continuation.
 Let's now study the interpreter for our new language. The branches for Num, Id, Add, and Fun are straightforward applications of the
 CPS transformation technique we already know.
-*/
 
+```scala mdoc
 def eval(e: Exp, env: Env, k: Value => Nothing) : Nothing = e match {
   case Num(n: Int) => k(NumV(n))
   case Id(x) => k(env(x))
@@ -91,25 +97,27 @@ def eval(e: Exp, env: Env, k: Value => Nothing) : Nothing = e match {
    * wrapped as a value using ContV. */
   case Letcc(param,body) => eval(body, env+(param -> ContV(k)), k)
 }
+```
 
-/**
+
 To make it easier to experiment with the interpreter this code provides the right initialization to eval. We have to give eval a
 continuation which represents the rest of the computation after eval is done. A small technical problem arises due to our usage of
 the return type "Nothing" for continuations, to emphasize that they do not return: The only way to implement a value that has this
 type is a function that does indeed not return. We do so by letting this function throw an exception. To keep track of the returned
 value we store it temporarily in a variable, catch the exception, and return the stored value.
-*/
 
+```scala mdoc
 def starteval(e: Exp) : Value = {
   var res : Value = null
   val s : Value => Nothing = (v) => { res = v; sys.error("program terminated") }
   try { eval(e, Map.empty, s) } catch { case e:Throwable => () }
   res
 }
+```
 
-/**
 Finally a small test of Letcc.
-*/
+
+```scala mdoc:silent
 val testprog = Add(1, Letcc("k", Add(2, Ap("k", 3))))
 
 assert(starteval(testprog) == NumV(4))

--- a/src/19-shift-reset/shift-reset.md
+++ b/src/19-shift-reset/shift-reset.md
@@ -3,27 +3,27 @@
 The content of this chapter is available as a Scala file [here.](./shift-reset.scala)
 
 
-```scala mdoc
-/**
-Delimited Continuations
-=======================
 The continuations we have seen so far represent the whole call-stack. Invoking a continuation
 was not like a function call because continuations never return a result. Invoking
 a continuation is more similar to a disciplined version of GOTO.
+
 However, the fact that continuations never return and represent the full call-stack often
 makes their use cumbersome. In particular, such continuations cannot be composed. The
 non-composability of continuations is visible in the fact that applications using
 first-class continuations often need to make use of mutable state.
+
 This is different with _delimited continuations_. Delimited continuations only represent
 a part of the call-stack, namely the part up to the next invocation of ``reset``. Delimited continuations
 behave like functions, that is, they return a value and are hence composable.
+
 Delimited continuations have many quite powerful applications, ranging from advanced exception handling
-to backtracking algorithms and probabilistc programming as well as so-called algebraic effects.
+to backtracking algorithms and probabilistic programming as well as so-called algebraic effects.
 Delimited continuations are available in Racket and many variants of Scheme, OCaML, Haskell and,
 thanks to work in our research group, in Java.
-Fortunately, a definitional interpreter for delimited continuations is pretty simple.
-*/
 
+Fortunately, a definitional interpreter for delimited continuations is pretty simple.
+
+```scala mdoc
 enum Exp:
   case Num(n: Int)
   case Id(name: Symbol)
@@ -36,9 +36,13 @@ enum Exp:
 object Exp:
   implicit def num2exp(n: Int): Exp = Num(n)
   implicit def id2exp(s: Symbol): Exp = Id(s)
+```
 
+```scala mdoc:invisible
 import Exp._
+```
 
+```scala mdoc
 sealed abstract class Value
 type Env = Map[Symbol, Value]
 case class NumV(n: Int) extends Value
@@ -66,13 +70,10 @@ def eval(e: Exp, env: Env, k: Value => Value) : Value = e match {
   case Reset(e) => k(eval(e,env,x=>x)) // reset the continuation to the identity function
   case Shift(param,body) => eval(body, env+(param -> ContV(k)), x=>x)  // wrap current continuation and reset continuation
 }
+```
 
-
-/**
 References:
+
 Olivier Danvy and Andre Filinski, “Abstracting Control,” LISP and Functional Programming, 1990.
 O. Kiselyov, An argument against call/cc. http://okmij.org/ftp/continuations/against-callcc.html
 O. Kiselyov, Introduction to programming with shift and reset. http://okmij.org/ftp/continuations/#tutorial
-*/
-
-```

--- a/src/20-monads-intro/monads-intro.md
+++ b/src/20-monads-intro/monads-intro.md
@@ -2,45 +2,47 @@
 
 The content of this chapter is available as a Scala file [here.](./monads-intro.scala)
 
-```scala mdoc
-/**
-Monads
-======
-*/
+
+```scala mdoc:invisible
 import scala.language.higherKinds
 import scala.language.reflectiveCalls
+```
 
-/**
 We have seen various patterns of function composition:
+
 - The environment passing style, in which an environment is passed down in recursive calls
 - The store passing style, in which a store is threaded in and out of every computation
-- The continuation passing style, in which every function call is a tail call.
+- The continuation passing style, in which every function call is a tail call.#
+
 Monads are way to abstract over such patterns of function composition.
+
 Motivation
 ----------
 Using monads, we can write code which can be parameterized to be in
 one of the styles above (or many others).
 Here is another common pattern of function composition. Suppose we have the following API of (nonsensical) functions:
-*/
+
+```scala mdoc
 def f(n: Int) : String = "x"
 def g(x: String) : Boolean = x == "x"
 def h(b: Boolean) : Int = if (b) 27 else sys.error("error")
 
 def clientCode = h(!g(f(27)+"z"))
+```
 
-/**
+
 Now suppose that these functions can possibly fail (say, because they involve remote communication). A common way to deal with such
 failures is to use the Option datatype:
-*/
 
+```scala mdoc
 def fOp(n: Int) : Option[String] = if (n < 100) Some("x") else None
 def gOp(x: String) : Option[Boolean] = Some(x == "x")
 def hOp(b: Boolean) : Option[Int] = if (b) Some(27) else None
+```
 
-/**
 However, now the clientCode must be changed rather dramatically:
-*/
 
+```scala mdoc
 def clientCodeOp =
   fOp(27) match {
     case Some(x) => gOp(x+"z") match {
@@ -49,68 +51,74 @@ def clientCodeOp =
       }
     case None => None
   }
+```
 
-/**
 We see a kind of pattern in this code. We have a value of type ``Option[A]``, but the next function we need to call requires an A and
 produces an ``Option[B]``. If the ``Option[A]`` value is ``None``, then the whole computation produces ``None``. If it is ``Some(x)``
 instead, we pass ``x`` to the function.
-We can capture this pattern in the form of a function:
-*/
 
+We can capture this pattern in the form of a function:
+
+```scala mdoc
 def bindOption[A,B](a: Option[A], f: A => Option[B]) : Option[B] = a match {
   case Some(x) => f(x)
   case None => None
 }
+```
 
-/**
-Using bindOption, we can rewrite the code above as follows:
-*/
+Using ``bindOption``, we can rewrite the code above as follows:
 
+```scala mdoc
 def clientCodeOpBind =
   bindOption(fOp(27), (x:String) =>
     bindOption(gOp(x+"z"), (y:Boolean) =>
       hOp(!y)))
+```
 
-/**
 Now suppose that our original client code was not ``h(!g(f(27)+"z"))``
 but instead ``!g(f(27)+"z")``. How can we express this with bind? This
 thing does not type check:
+```scala mdoc
     def clientCode =
       f(27) bind ((x: String) =>
       g(x+"z") bind  ((y: Boolean) =>
       !y))
-One way to fix the situation is to insert a call to ``Some``, like so:
-*/
+```
 
+One way to fix the situation is to insert a call to ``Some``, like so:  
+
+```scala mdoc
 def clientCode2Op =
   bindOption(fOp(27), ((x: String) =>
   bindOption(gOp(x+"z"), ((y: Boolean) =>
   Some(!y)))))
+```
 
-/**
 While this works, it is incompatible with our original goal of abstracting over the function composition pattern, because the
 Some constructor exposes what kind of pattern we are currently dealing with. Hence let's abstract over it by adding a second
-function "unit" to our function composition interface:
-*/
+function ``unit`` to our function composition interface:
 
+```scala mdoc
 def unit[A](x: A) : Option[A] = Some(x)
 
 def clientCode2OpUnit =
   bindOption(fOp(27), ((x: String) =>
   bindOption(gOp(x+"z"), ((y: Boolean) =>
   unit(!y)))))
+```
 
-/**
-This looks better, but the types of unit and bind still reveal that we are dealing with the "Option" function composition pattern.
+This looks better, but the types of unit and bind still reveal that we are dealing with the ``Option`` function composition pattern.
 Let's abstract over the Option type constructor by turning the type constructor into a parameter. The resulting triple
-(type constructor, unit function, bind function) is called a _monad_. Certain conditions (the "monad laws") on unit and bind also
+(type constructor, unit function, bind function) is called a _monad_. Certain conditions (the "monad laws") on ``unit`` and ``bind`` also
 need to hold to make it a true monad, but we'll defer a discussion of these conditions until later.
+
+
 The Monad Interface
--------------------
+-------------------  
 
 So here it is: The Monad interface.
-*/
 
+```scala mdoc
 trait Monad[M[_]] {
   def unit[A](a: A): M[A]
   def bind[A,B](m: M[A], f: A => M[B]): M[B]
@@ -121,21 +129,21 @@ trait Monad[M[_]] {
   // 2) Bind enjoys an associative property
   //     bind(bind(x,f),g) == bind(x, y => bind(f(y),g))
 }
+```
 
-/**
 Using this interface, we can now make clientCode depend only on this interface, but no longer on the Option type:
-*/
 
+```scala mdoc
 def clientCode2Op(m: Monad[Option]) =
   m.bind(fOp(27), (x: String) =>
   m.bind(gOp(x+"z"), (y: Boolean) =>
   m.unit(!y)))
+```
 
-/**
 If the API is parametric in the monad, we can make the client code fully parametric, too. We model the monad object as an
 implicit parameter to save the work of passing on the monad in every call.
-*/
 
+```scala mdoc
 def fM[M[_]](n: Int)(using m: Monad[M]) : M[String] = sys.error("not implemented")
 def gM[M[_]](x: String)(using m: Monad[M]) : M[Boolean] = sys.error("not implemented")
 def hM[M[_]](b: Boolean)(using m: Monad[M]) : M[Int] = sys.error("not implemented")
@@ -144,59 +152,68 @@ def clientCode2[M[_]](using m: Monad[M]) =
   m.bind(fM(27), (x: String) =>
   m.bind(gM(x+"z"), (y: Boolean) =>
   m.unit(!y)))
+```
 
-/**
 For-Comprehension Syntax
 ------------------------
 All these nested calls to bind can make the code hard to read. Luckily, there is a notation called "monad comprehension" to make
 monadic code look simpler. Monad comprehensions are directly supported in Haskell and some other languages. In Scala, we can
 piggy-back on the "For comprehension" syntax instead.
 A "for comprehension"  is usually used for lists and other collections. For instance:
+
+```mdoc:silent
     val l = List(List(1,2), List(3,4))
     assert( (for { x <- l; y <- x } yield y+1) == List(2,3,4,5))
+```
+
 The Scala compiler desugars the for-comprehension above into calls of the standard map and flatMap functions. That is, the above
 for comprehension is equivalent to:
+
+```scala mdoc:silent
     assert(l.flatMap(x => x.map(y => y+1)) == List(2,3,4,5))
+```
+
 We will make use of for-comprehension syntax by supporting both ``flatMap`` (which is like ``bind``) and ``map`` (which is like ``fmap``).
 We support these functions by an implicit conversion to an object that supports these functions as follows:
-*/
 
+```scala mdoc
 extension [A, M[_]](m: M[A])(using mm: Monad[M])
   def map[B](f: A => B): M[B] = mm.bind(m, (x: A) => mm.unit(f(x)))
   def flatMap[B](f: A => M[B]): M[B] = mm.bind(m, f)
+```
 
-/**
 Using the new support for for-comprehension syntax, we can rewrite our client code as follows: Given the API from above,
 
+```scala mdoc
 def fOp(n: Int) : Option[String] = if (n < 100) Some("x") else None
 def gOp(x: String) : Option[Boolean] = Some(x == "x")
 def hOp(b: Boolean) : Option[Int] = if (b) Some(27) else None
+```
 
-
-we can now rewrite this:
-
+We can now rewrite this
+```scala mdoc
 def clientCode2Op(m: Monad[Option]) =
   m.bind(fOp(27), (x: String) =>
   m.bind(gOp(x+"z"), (y: Boolean) =>
   m.unit(!y)))
-
+```
 to this:
-*/
 
+```scala mdoc
 def clientCode2OpFor(using m: Monad[Option]) =
   for {
     x <- fOp(27)
     y <- gOp(x+"z")
   } yield !y
+```
 
 
-/**
 The Option Monad
 ----------------
 Let's look at some concrete monads now. We have of course already seen one particular Monad: The Option monad. This monad is also
 sometimes called the Maybe monad.
-*/
 
+```scala mdoc
 object OptionMonad extends Monad[Option] {
   override def bind[A,B](a: Option[A], f: A => Option[B]) : Option[B] =
     a match {
@@ -205,92 +222,109 @@ object OptionMonad extends Monad[Option] {
     }
   override def unit[A](a: A) = Some(a)
 }
+```
 
-/**
 We can now parameterize clientCode with OptionMonad.
-*/
 
+```scala mdoc
 def v : Option[Boolean] = clientCode2Op(OptionMonad)
+```
 
-/**
 There are many other sensible monads. Before we discuss those, let us discuss whether there are useful functions that are generic
 enough to be useful for many different monads. Here are some of these functions:
-*/
 
-// fmap turns every function between A and B into a function between M[A] and M[B]
+
+``fmap`` turns every function between ``A`` and ``B`` into a function between ``M[A]`` and ``M[B]``:
+
+```scala mdoc
 def fmap[M[_],A,B](f: A => B)(using m: Monad[M]): M[A] => M[B] = a => m.bind(a,(x:A) => m.unit(f(x)))
-// In fancy category theory terms, we can say that every monad is a functor.
+```
+In fancy category theory terms, we can say that every monad is a functor.
 
-// sequence composes a list of monadic values into a single monadic value which is a list.
+
+``sequence`` composes a list of monadic values into a single monadic value which is a list.
+```scala mdoc
 def sequence[M[_],A](l: List[M[A]])(using m: Monad[M]) : M[List[A]] = l match {
   case x :: xs => m.bind(x, (y: A) =>
     m.bind(sequence(xs), (ys : List[A]) =>
       m.unit(y :: ys)))
   case Nil => m.unit(List.empty)
 }
+```
 
-// mapM composes sequence and the standard map function.
+``mapM`` composes ``sequence`` and the standard ``map`` function:
+```scala mdoc
 def mapM[M[_],A,B](f : A => M[B], l: List[A])(using m: Monad[M]) : M[List[B]] =
   sequence(l.map(f))
+```
 
-// join is another useful function to unwrap a layer of monads
-// in category theory, monads are defined via unit (denoted by the greek letter "eta")
-// and join ("mu") instead of unit and bind. There are additional "naturality" and
-// "coherence conditions" that make the category theory definition equivalent to ours.
+``join`` is another useful function to unwrap a layer of monads.
+In category theory, monads are defined via ``unit`` (denoted by the greek letter ``η``)
+and ``join (μ)`` instead of ``unit`` and ``bind``. There are additional "naturality" and
+"coherence conditions" that make the category theory definition equivalent to ours.
+
+```scala mdoc
 def join[M[_],A](x : M[M[A]])(using m: Monad[M]) : M[A] = m.bind(x, (y : M[A]) => y)
+```
 
-/** Here are some other common monads:
+Here are some other common monads:
+
 The Identity Monad
 ------------------
 
 The _identity monad_ is the simplest monad which corresponds to ordinary function application. If we parameterize monadic code
 with the Identity monad, we get the behavior of the original non-monadic code.
-*/
 
-type Id[X] = X
+```scala mdoc
+type Id[X] = X   
 object IdentityMonad extends Monad[Id] {
   def bind[A,B](x: A, f: A => B) : B = f(x)
   def unit[A](a: A) : A = a
 }
+```
 
 
 
-/**
 The Reader Monad
 ----------------
 This is the _reader monad_, a.k.a. _environment monad_. It captures the essence of "environment passing style".
-*/
 
-// The type parameter ({type M[A] = R => A})#M looks complicated, but
-// it is merely "currying" the function arrow type constructor.
-// The type constructor which is created here is M[A] = R => A
+
+The type parameter ``({type M[A] = R => A})#M`` looks complicated, but
+it is merely "currying" the function arrow type constructor.
+
+The type constructor which is created here is ``M[A] = R => A``
+
+```scala mdoc
 trait ReaderMonad[R] extends Monad[[A] =>> R => A] {
   override def bind[A,B](x: R => A, f: A => R => B) : R => B = r => f(x(r))(r) // pass the "environment" r into both computations
   override def unit[A](a: A) : R => A = (_) => a
 }
+```
 
-/**
-Example: Suppose that all functions in our API above depend on some kind of environment, say, the current configuration.
-For simplicitly, let's assume  that the current configuration is just an ``Int```, hence all functions have a return type of
-the form ``Int => A```:
-*/
+__Example__: Suppose that all functions in our API above depend on some kind of environment, say, the current configuration.
+For simplicitly, let's assume  that the current configuration is just an ``Int``, hence all functions have a return type of
+the form ``Int => A``:
 
+```scala mdoc
 def fRead(n: Int) : Int => String  = sys.error("not implemented")
 def gRead(x: String) : Int => Boolean  = sys.error("not implemented")
 def hRead(b: Boolean) : Int => Int = sys.error("not implemented")
+```
 
-/**
 Our original code,
+```scala mdoc
     def clientCode = h(!g(f(27)+"z"))
+```
 becomes :
-*/
 
+```scala mdoc
 def clientCodeRead(env: Int) = hRead(!gRead(fRead(27)(env)+"z")(env))(env)
+```
 
-/**
-In monadic form, the explicit handling of the environment disappears again.
-*/
+In monadic form, the explicit handling of the environment disappears again:
 
+```scala mdoc
 def clientCode2Read(using m: ReaderMonad[Int]) =
   m.bind(fRead(27), ((x: String) =>
   m.bind(gRead(x+"z"), ((y: Boolean) =>
@@ -302,45 +336,45 @@ def clientCode2ReadFor(using m: ReaderMonad[Int]) =
       x <- fRead(27)
       y <- gRead(x+"z")
     } yield !y
+```
 
-/**
 
 The State Monad
 ---------------
 
 The _state monad_, in which computations depend on a state ``S``
 which is threaded through the computations, is defind as follows:
-*/
 
+```scala mdoc
 trait StateMonad[S] extends Monad[[A] =>> S => (A,S)] {
   override def bind[A,B](x: S => (A,S), f: A => S => (B,S)) : S => (B,S) =
     s => x(s) match { case (y,s2) => f(y)(s2) } // thread the state through the computations
   override def unit[A](a: A) : S => (A,S) = s => (a,s)
 }
+```
 
-/**
 Example: Assume that our API maintains a state which (for simplicity) we assume to be a single integer. That is, it would look like this:
-*/
 
+```scala mdoc
 def fState(n: Int) : Int => (String,Int)  = sys.error("not implemented")
 def gState(x: String) : Int => (Boolean,Int)  = sys.error("not implemented")
 def hState(b: Boolean) : Int => (Int,Int) = sys.error("not implemented")
+```
 
-/**
 The original code,
-   def clientCode = h(!g(f(27)+"z"))
+   ``def clientCode = h(!g(f(27)+"z"))``
 becomes :
-*/
 
+```scala mdoc
 def clientCodeState(s: Int) =
   fState(27)(s) match {
     case (x,s2) => gState(x+"z")(s2) match {
       case (y,s3) => hState(!y)(s3) }}
+```
 
-/**
-In monadic style, however, the state handling disappears once more.
-*/
+In monadic style, however, the state handling disappears once more:
 
+```scala mdoc
 def clientCode2State(using m: StateMonad[Int]) =
   m.bind(fState(27), ((x: String) =>
   m.bind(gState(x+"z"), ((y: Boolean) =>
@@ -352,38 +386,39 @@ def clientCode2State(using m: StateMonad[Int]) =
 //    x <- fState(27)
 //    y <- gState(x+"z")
 //  } yield !y
+```
 
-/**
+
 The List Monad
---------------
-In the _list monad_, computations produce lists of results. The bind operator combines all those results in a single list.
-*/
+--------------  
+In the _list monad_, computations produce lists of results. The ``bind`` operator combines all those results in a single list.
+
+```scala mdoc
 object ListMonad extends Monad[List] {
   override def bind[A,B](x: List[A], f: A => List[B]) : List[B] = x.flatMap(f) // apply f to each element, concatenate the resulting lists
   override def unit[A](a: A) = List(a)
 }
+```
+__Example__: Assume that our API functions return lists of results, and our client code must exercise the combination of all possible answers.
 
-/**
-Example: Assume that our API functions return lists of results, and our client code must exercise the combination of all possible answers.
-*/
-
+```scala mdoc
 def fList(n: Int) : List[String] = sys.error("not implemented")
 def gList(x: String) : List[Boolean] = sys.error("not implemented")
 def hList(b: Boolean) : List[Int] = sys.error("not implemented")
+```
 
-/**
 The original code,
-    def clientCode = h(!g(f(27)+"z"))
+    ``def clientCode = h(!g(f(27)+"z"))``
 becomes :
-*/
 
+```scala mdoc
 def clientCodeList =
   fList(27).map(x => gList(x+"z")).flatten.map(y => hList(!y)).flatten
+```
 
-/**
 The monadic version of the client code stays the same, as expected:
-*/
 
+```scala mdoc  
 def clientCode2List = {
   given Monad[List] = ListMonad
   for {
@@ -391,48 +426,47 @@ def clientCode2List = {
     y <- gList(x+"z")
   } yield !y
 }
+```
 
-/**
 The Continuation Monad
-----------------------
+----------------------  
 The last monad we are going to present is the continuation monad,  which stands for computations that are continuations.
-*/
 
 
+```scala mdoc
 trait ContinuationMonad[R] extends Monad[[A] =>> (A => R) => R] {
   type Cont[X] = (X => R) => R
 
   override def bind[A,B](x: Cont[A], f: A => Cont[B]) : Cont[B] =
-     k => x( a => f(a)(k)) // construct continuation for x that calls f with the result of x
+     k => x( a => f(a)(k)) // construct continuation for x that calls f with the result of x               
   override def unit[A](a: A) : Cont[A] = k => k(a)
 
   // callcc is like letcc; the difference is that letcc binds a name, whereas callcc expects a function as argument
   // That means that letcc(k,...) is expressed as callcc( k => ...).
   def callcc[A,B](f: (A => Cont[B]) => Cont[A]   ) : Cont[A] = k => f( (a:A) => (_:B=>R) => k(a))(k)
 }
+```
 
-/**
-Example: Suppose our API was CPS-transformed:
-*/
+__Example__: Suppose our API was CPS-transformed:
 
+```scala mdoc
 def fCPS[R](n: Int) : (String => R) => R = sys.error("not implemented")
 def gCPS[R](x: String) : (Boolean => R) => R = sys.error("not implemented")
 def hCPS[R](b: Boolean) : (Int => R) => R = sys.error("not implemented")
+```
 
-/**
 The original code,
-    def clientCode = h(!g(f(27)+"z"))
+    ``def clientCode = h(!g(f(27)+"z"))``
 becomes :
-*/
 
+```scala mdoc
 def clientCodeCPS[R]: (Int => R) => R =
   k => fCPS(27)( (x: String) => gCPS(x+"z")( (y: Boolean) =>  hCPS(!y)(k)))
+```
 
-/**
-The monadic version hides the CPS transformation in the operations of the Monad.
-*/
+The monadic version hides the CPS transformation in the operations of the Monad.  
 
-
+```scala mdoc
 def clientCode2CPS[R](using m: ContinuationMonad[R]) =
   m.bind(fCPS(27), ((x: String) =>
   m.bind(gCPS(x+"z"), ((y: Boolean) =>
@@ -444,10 +478,11 @@ def clientCode2CPS[R](using m: ContinuationMonad[R]) =
 //    x <- fCPS(27)
 //    y <- gCPS(x+"z")
 //  } yield !y
+```
 
+Let's implement ``1 + (2 + 3)`` in monadic style and implicitly CPS-transform using the continuation monad:
 
-// let's implement 1 + (2 + 3) in monadic style and implicitly CPS-transform using the continuation monad
-
+```scala mdoc
 // unfortunately we can, again, not use for-comprehension syntax
 def ex123[R](using m: ContinuationMonad[R])  = {
   m.bind(
@@ -457,9 +492,11 @@ def ex123[R](using m: ContinuationMonad[R])  = {
 }
 
 def runEx123 = ex123(using new ContinuationMonad[Int]{})(x=>x)
+```
 
-// let's implement the (+ 1 (let/cc k (+ 2 (k 3)))) example using callcc
+Let's implement the ``(+ 1 (let/cc k (+ 2 (k 3))))`` example using ``callcc``
 
+```scala mdoc
 def excallcc[R](using m: ContinuationMonad[R])  = {
   m.bind(
     m.bind(m.unit(2),
@@ -467,23 +504,27 @@ def excallcc[R](using m: ContinuationMonad[R])  = {
     (five:Int) => m.unit(1+five))
 }
 def runExcallcc = excallcc(using new ContinuationMonad[Int]{})(x=>x)
+```
 
-// Remember how we had to CPS-transform the "map" function in the "allCosts" example when we talked about continuations?
-// Now we can define a monadic version of "map" that works for any monad, including the continuation monad
+Remember how we had to CPS-transform the "map" function in the "allCosts" example when we talked about continuations?
+Now we can define a monadic version of "map" that works for any monad, including the continuation monad:
 
+```scala mdoc
 def mapM[M[_],A,B](x: List[A], f: A => M[B])(using m: Monad[M]) : M[List[B]] = sequence(x.map(f))
+```
 
 
-/**
 Monad Transformers
 ------------------
+
 The purpose of monad transformers is to compose monads.
 For instance, what if we want to have both the list monad and the option monad
 at the same time? Such situations arise very often in practical code.
+
 One solution is to have a monad transformer version of each monad, which is
 parameterized with another monad. We show this for the Option monad case.
-*/
 
+```scala mdoc
 type OptionT[M[_]] = { type x[A] = M[Option[A]] }
 
 
@@ -495,11 +536,14 @@ class OptionTMonad[M[_]](val m : Monad[M]) extends Monad[OptionT[M]#x] {
 
   override def unit[A](a: A) = m.unit(Some(a))
 
-  def lift[A](x: M[A]) : M[Option[A]] = m.bind(x, (a: A) => m.unit(Some(a)))
+  def lift[A](x: M[A]) : M[Option[A]] = m.bind(x, (a: A) => m.unit(Some(a)))                                   
 }
+```
 
+```scala mdoc:silent
 val ListOptionM = new OptionTMonad(ListMonad)
-
+```
+```scala mdoc
 // in this case, for-comprehension syntax doesn't work because it clashes with the built-in support for
 // for-comprehensions for lists :-(
 def example = {
@@ -520,13 +564,11 @@ def example3 = {
 def example4 = {
   val m = ListOptionM
   m.bind(List(Some(3),Some(4)), (x: Int) => if (x > 3) m.m.unit(None) else m.unit(x*2))
-}
+}        
+```
 
-/*
-Monad transformers are a standard way to compose monads, e.g., in Haskell and in scalaz.
+Monad transformers are a standard way to compose monads, e.g., in Haskell and in Scala.
 They have a number of well-known disadvantages. For instance, one needs additional transformer
 versions of monads and the required lifting sometimes destroys modularity.
 There are a number of alternative proposals to monad transformers, such as "extensible effects".
 https://hackage.haskell.org/package/extensible-effects
-*/
-```


### PR DESCRIPTION
I reordered the chapters from 15-20. However there are two problems I am facing:

1. For some reason the github-deployment action in the workflow of my fork always fails the GitHub-Deployment Workflow, so I dont know, if it is just a bug of this action for my fork or if it also is a problem in the main project. 

``Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌``

2. In Chapter 17: ``first-class-continuations.md`` the mdoc build fails. I guess it is because of the ``sealed abstract class Value`` as every subclass needs to be in the same file as the sealed abstract class. I don't know a workaround for it yet, except wrapping the code at the moment the Value class is introduced to the end.

line 49
```scala
sealed abstract class Value
type Env = Map[String, Value]
case class NumV(n: Int) extends Value
case class ClosureV(f: Fun, env: Env) extends Value

case class ContV(f: Value => Nothing) extends Value
```
