### PR TITLE
changed link to dependent git repository

### DIFF
--- a/download_questionnaire_module.sh
+++ b/download_questionnaire_module.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl -ssL -O https://github.com/se-tuebingen/interactive-textbooks/releases/latest/download/questionnaire.js
+curl -ssL -O https://github.com/se-tuebingen/questionnaire/releases/latest/download/questionnaire.js


### PR DESCRIPTION
Link of the dependent git repository changed: https://github.com/se-tuebingen/questionnaire/